### PR TITLE
ci(gradle): Change the Sonar credentials to match the project.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,9 +93,9 @@ android {
 
 sonar {
     properties {
-        property("sonar.projectKey", "gf_android-sample")
-        property("sonar.projectName", "Android-Sample")
-        property("sonar.organization", "gabrielfleischer")
+        property("sonar.projectKey", "SwEnt-Group13_unio")
+        property("sonar.projectName", "unio")
+        property("sonar.organization", "swent-group13")
         property("sonar.host.url", "https://sonarcloud.io")
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
         property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")


### PR DESCRIPTION
This change sets the `sonar.projectKey`, `sonar.projectName`, and `sonar.organization` properties of `app/build.gradle.kts` with the values provided by Sonar, for it to work properly in the CI.