### PR TITLE
chore(model/association): Create view model for the association database.

### DIFF
--- a/app/src/main/java/com/android/unio/model/association/AssociationRepository.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationRepository.kt
@@ -1,5 +1,7 @@
 package com.android.unio.model.association
 
 interface AssociationRepository {
+  fun init(onSuccess: () -> Unit)
+
   fun getAssociations(onSuccess: (List<Association>) -> Unit, onFailure: (Exception) -> Unit)
 }

--- a/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
@@ -1,9 +1,19 @@
 package com.android.unio.model.association
 
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 
 class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : AssociationRepository {
+
+  override fun init(onSuccess: () -> Unit) {
+    Firebase.auth.addAuthStateListener {
+      if (it.currentUser != null) {
+        onSuccess()
+      }
+    }
+  }
 
   override fun getAssociations(
       onSuccess: (List<Association>) -> Unit,

--- a/app/src/main/java/com/android/unio/model/association/ExploreViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/association/ExploreViewModel.kt
@@ -1,0 +1,41 @@
+package com.android.unio.model.association
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class ExploreViewModel(val repository: AssociationRepositoryFirestore) : ViewModel() {
+  private val _associations = MutableStateFlow<List<Association>>(emptyList())
+  val associations: StateFlow<List<Association>> = _associations
+
+  init {
+    repository.init { fetchAssociations() }
+  }
+
+  companion object {
+    val Factory: ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+          @Suppress("UNCHECKED_CAST")
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ExploreViewModel(AssociationRepositoryFirestore(Firebase.firestore)) as T
+          }
+        }
+  }
+
+  fun fetchAssociations() {
+    viewModelScope.launch {
+      repository.getAssociations(
+          onSuccess = { fetchedAssociations -> _associations.value = fetchedAssociations },
+          onFailure = { exception ->
+            _associations.value = emptyList()
+            Log.e("ExploreViewModel", "Failed to fetch associations", exception)
+          })
+    }
+  }
+}

--- a/app/src/test/java/com/android/unio/model/association/ExploreViewModelTest.kt
+++ b/app/src/test/java/com/android/unio/model/association/ExploreViewModelTest.kt
@@ -1,0 +1,114 @@
+package com.android.unio.model.association
+
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+
+class ExploreViewModelTest {
+  @Mock private lateinit var repository: AssociationRepositoryFirestore
+  private lateinit var viewModel: ExploreViewModel
+
+  @OptIn(ExperimentalCoroutinesApi::class) private val testDispatcher = UnconfinedTestDispatcher()
+
+  private val testAssociations =
+      listOf(
+          Association(
+              uid = "1",
+              acronym = "ACM",
+              fullName = "Association for Computing Machinery",
+              description =
+                  "ACM is the world's largest educational and scientific computing society.",
+              members = listOf("1", "2")),
+          Association(
+              uid = "2",
+              acronym = "IEEE",
+              fullName = "Institute of Electrical and Electronics Engineers",
+              description = "IEEE is the world's largest technical professional organization.",
+              members = listOf("3", "4")))
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    Dispatchers.setMain(testDispatcher)
+
+    viewModel = ExploreViewModel(repository)
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun testGetAssociations() {
+    `when`(repository.getAssociations(any(), any())).thenAnswer { invocation ->
+      val onSuccess = invocation.arguments[0] as (List<Association>) -> Unit
+      onSuccess(testAssociations)
+    }
+
+    viewModel.fetchAssociations()
+    assertEquals(testAssociations, viewModel.associations.value)
+
+    runBlocking {
+      val result = viewModel.associations.first()
+
+      assertEquals(2, result.size)
+      assertEquals("ACM", result[0].acronym)
+      assertEquals("IEEE", result[1].acronym)
+    }
+
+    // Verify that the repository method was called
+    verify(repository).getAssociations(any(), any())
+  }
+
+  @Test
+  fun testGetAssociationsError() {
+    `when`(repository.getAssociations(any(), any())).thenAnswer { invocation ->
+      val onFailure = invocation.arguments[1] as (Exception) -> Unit
+      onFailure(Exception("Test exception"))
+    }
+
+    viewModel.fetchAssociations()
+    assert(viewModel.associations.value.isEmpty())
+
+    // Verify that the repository method was called
+    verify(repository).getAssociations(any(), any())
+  }
+
+  @Test
+  fun testInitFetchesAssociations() {
+    // Mock the init method
+    `when`(repository.init(any())).thenAnswer { invocation ->
+      val onSuccess = invocation.arguments[0] as () -> Unit
+      onSuccess()
+    }
+
+    `when`(repository.getAssociations(any(), any())).thenAnswer { invocation ->
+      val onSuccess = invocation.arguments[0] as (List<Association>) -> Unit
+      onSuccess(testAssociations)
+    }
+
+    val newViewModel = ExploreViewModel(repository)
+
+    runBlocking {
+      val result = newViewModel.associations.first()
+      assertEquals(2, result.size)
+    }
+
+    verify(repository).getAssociations(any(), any())
+  }
+}


### PR DESCRIPTION
The explore view model will enable us to get the list of associations from the firebase database. This will be useful for screens such as the explore screen, which will display all associations, sorted vertically by category, and horizontally by some other logic (or none).