### PR TITLE
feat(explore): implement base of the explore screen

### DIFF
--- a/app/src/androidTest/java/com/android/unio/ui/ExploreScreenTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ExploreScreenTest.kt
@@ -1,0 +1,30 @@
+package com.android.unio.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import com.android.unio.ui.explore.ExploreScreen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class ExploreScreen {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun displayAllComponents() {
+        composeTestRule.setContent { ExploreScreen() }
+        composeTestRule.onNodeWithTag("exploreScreen").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
+    }
+
+}

--- a/app/src/androidTest/java/com/android/unio/ui/ExploreScreenTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ExploreScreenTest.kt
@@ -1,30 +1,19 @@
 package com.android.unio.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextClearance
-import androidx.compose.ui.test.performTextInput
 import com.android.unio.ui.explore.ExploreScreen
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.any
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
 
 class ExploreScreen {
-    @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Test
-    fun displayAllComponents() {
-        composeTestRule.setContent { ExploreScreen() }
-        composeTestRule.onNodeWithTag("exploreScreen").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
-    }
-
+  @Test
+  fun displayAllComponents() {
+    composeTestRule.setContent { ExploreScreen() }
+    composeTestRule.onNodeWithTag("exploreScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/android/unio/ui/ExploreScreenTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ExploreScreenTest.kt
@@ -3,7 +3,11 @@ package com.android.unio.ui
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import com.android.unio.model.association.AssociationType
 import com.android.unio.ui.explore.ExploreScreen
+import com.android.unio.ui.explore.getCategoryNameWithFirstLetterUppercase
+import com.android.unio.ui.explore.getFilteredAssociationsByCategoryAndAlphabeticalOrder
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
@@ -15,5 +19,27 @@ class ExploreScreen {
     composeTestRule.setContent { ExploreScreen() }
     composeTestRule.onNodeWithTag("exploreScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
+  }
+
+  @Test
+  fun testGetFilteredAssociationsByCategory() {
+    val musicAssociations =
+        getFilteredAssociationsByCategoryAndAlphabeticalOrder(AssociationType.MUSIC)
+    assertEquals(1, musicAssociations.size)
+    assertEquals("Musical", musicAssociations[0].association.acronym)
+
+    val festivalAssociations =
+        getFilteredAssociationsByCategoryAndAlphabeticalOrder(AssociationType.FESTIVALS)
+    assertEquals(4, festivalAssociations.size)
+    assertEquals("Artiphys", festivalAssociations[0].association.acronym)
+  }
+
+  @Test
+  fun testGetCategoryNameWithFirstLetterUppercase() {
+    val musicCategory = getCategoryNameWithFirstLetterUppercase(AssociationType.MUSIC)
+    assertEquals("Music", musicCategory)
+
+    val festivalCategory = getCategoryNameWithFirstLetterUppercase(AssociationType.FESTIVALS)
+    assertEquals("Festivals", festivalCategory)
   }
 }

--- a/app/src/main/java/com/android/unio/model/association/MockAssociations.kt
+++ b/app/src/main/java/com/android/unio/model/association/MockAssociations.kt
@@ -1,0 +1,75 @@
+package com.android.unio.model.association
+
+enum class AssociationType {
+  MUSIC,
+  FESTIVALS,
+  INNOVATION,
+  FACULTIES,
+  SOCIAL,
+  TECH,
+  OTHER
+}
+
+data class MockAssociation(val association: Association, val type: AssociationType)
+
+val mockAssociations =
+    listOf(
+        MockAssociation(
+            Association(
+                uid = "1",
+                acronym = "Musical",
+                fullName = "Musical Association",
+                description =
+                    "AGEPoly Commission – stimulation of the practice of music on the campus",
+                members = emptyList()),
+            AssociationType.MUSIC),
+        MockAssociation(
+            Association(
+                uid = "2",
+                acronym = "Nuit De la Magistrale",
+                fullName = "Nuit De la Magistrale Association",
+                description =
+                    "AGEPoly Commission – party following the formal Magistrale Graduation Ceremony",
+                members = emptyList()),
+            AssociationType.FESTIVALS),
+        MockAssociation(
+            Association(
+                uid = "3",
+                acronym = "Balélec",
+                fullName = "Festival Balélec",
+                description = "Open-air unique en Suisse, organisée par des bénévoles étudiants.",
+                members = emptyList()),
+            AssociationType.FESTIVALS),
+        MockAssociation(
+            Association(
+                uid = "4",
+                acronym = "Artiphys",
+                fullName = "Festival Artiphys",
+                description = "Festival à l'EPFL",
+                members = emptyList()),
+            AssociationType.FESTIVALS),
+        MockAssociation(
+            Association(
+                uid = "5",
+                acronym = "Sysmic",
+                fullName = "Festival Sysmic",
+                description = "Festival à l'EPFL",
+                members = emptyList()),
+            AssociationType.FESTIVALS),
+        MockAssociation(
+            Association(
+                uid = "6",
+                acronym = "IFL",
+                fullName = "Innovation Forum Lausanne",
+                description = "Innovation Forum Lausanne",
+                members = emptyList()),
+            AssociationType.INNOVATION),
+        MockAssociation(
+            Association(
+                uid = "7",
+                acronym = "Clic",
+                fullName = "Clic Association",
+                description = "Association of EPFL Students of IC Faculty",
+                members = emptyList()),
+            AssociationType.FACULTIES),
+    )

--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -1,0 +1,203 @@
+package com.android.unio.ui.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.android.unio.model.association.Association
+
+@Composable
+fun ExploreScreen() {
+    Scaffold(
+        modifier = Modifier.testTag("exploreScreen"),
+        /**
+         * Here, we should have the bottom navigation bar.
+         */
+        content = { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+            ) {
+                OutlinedTextField(
+                    value = "",
+                    onValueChange = {},
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp)
+                        .testTag("searchBar"),
+                    placeholder = { Text("Search") },
+                    trailingIcon = { Icon(Icons.Default.Search, contentDescription = "Search icon") }
+                )
+
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    AssociationType.entries.forEach { category ->
+                        val filteredAssociations = mockAssociations
+                            .filter { it.type == category }
+                            .sortedBy { it.association.acronym }
+
+                        if (filteredAssociations.isNotEmpty()) {
+                            item {
+                                Text(
+                                    text = category.name.lowercase().replaceFirstChar { it.uppercase() },
+                                    fontWeight = FontWeight.Bold,
+                                    modifier = Modifier
+                                        .padding(horizontal = 16.dp)
+                                        .testTag("categoryTitle")
+                                )
+
+                                // Horizontal scrollable list of associations
+                                LazyRow(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                                ) {
+                                    items(filteredAssociations.size) { index ->
+                                        AssociationItem(filteredAssociations[index].association)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    )
+}
+
+@Composable
+fun AssociationItem(association: Association) {
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .width(80.dp)
+        // Interaction (to see detailed screen about an association) can be defined here,
+        // with the .clickable modifier
+    ) {
+        /**
+         * Placeholder for the image later on when we find a way to get and store them,
+         * for now just a gray box
+         */
+        Box(
+            modifier = Modifier
+                .size(64.dp)
+                .background(Color.LightGray, shape = RoundedCornerShape(8.dp))
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = association.acronym,
+            fontWeight = FontWeight.Normal,
+            modifier = Modifier.fillMaxWidth(),
+            maxLines = 1
+        )
+    }
+}
+
+/**
+ * Everything below is mock data. This file (and other classes)
+ * should later be adapted to get data from the association repository.
+ */
+enum class AssociationType {
+    MUSIC, FESTIVALS, INNOVATION, FACULTIES, SOCIAL, TECH, OTHER
+}
+
+data class MockAssociation(val association: Association, val type: AssociationType)
+
+val mockAssociations = listOf(
+    MockAssociation(
+        Association(
+            uid = "1",
+            acronym = "Musical",
+            fullName = "Musical Association",
+            description = "AGEPoly Commission – stimulation of the practice of music on the campus",
+            members = emptyList()
+        ),
+        AssociationType.MUSIC
+    ),
+    MockAssociation(
+        Association(
+            uid = "2",
+            acronym = "Nuit De la Magistrale",
+            fullName = "Nuit De la Magistrale Association",
+            description = "AGEPoly Commission – party following the formal Magistrale Graduation Ceremony",
+            members = emptyList()
+        ),
+        AssociationType.FESTIVALS
+    ),
+    MockAssociation(
+        Association(
+            uid = "3",
+            acronym = "Balélec",
+            fullName = "Festival Balélec",
+            description = "Open-air unique en Suisse, organisée par des bénévoles étudiants.",
+            members = emptyList()
+        ),
+        AssociationType.FESTIVALS
+    ),
+    MockAssociation(
+        Association(
+            uid = "4",
+            acronym = "Artiphys",
+            fullName = "Festival Artiphys",
+            description = "Festival à l'EPFL",
+            members = emptyList()
+        ),
+        AssociationType.FESTIVALS
+    ),
+    MockAssociation(
+        Association(
+            uid = "5",
+            acronym = "Sysmic",
+            fullName = "Festival Sysmic",
+            description = "Festival à l'EPFL",
+            members = emptyList()
+        ),
+        AssociationType.FESTIVALS
+    ),
+    MockAssociation(
+        Association(
+            uid = "6",
+            acronym = "IFL",
+            fullName = "Innovation Forum Lausanne",
+            description = "Innovation Forum Lausanne",
+            members = emptyList()
+        ),
+        AssociationType.INNOVATION
+    ),
+    MockAssociation(
+        Association(
+            uid = "7",
+            acronym = "Clic",
+            fullName = "Clic Association",
+            description = "Association of EPFL Students of IC Faculty",
+            members = emptyList()
+        ),
+        AssociationType.FACULTIES
+    ),
+)

--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -56,7 +56,8 @@ fun ExploreScreenContent(padding: PaddingValues) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
           AssociationType.entries.forEach { category ->
-            val filteredAssociations = getFilteredAssociationsByCategory(category)
+            val filteredAssociations =
+                getFilteredAssociationsByCategoryAndAlphabeticalOrder(category)
 
             if (filteredAssociations.isNotEmpty()) {
               item {
@@ -106,7 +107,9 @@ fun AssociationItem(association: Association) {
 }
 
 /** Returns a list of associations filtered by the given category. */
-fun getFilteredAssociationsByCategory(category: AssociationType): List<MockAssociation> {
+fun getFilteredAssociationsByCategoryAndAlphabeticalOrder(
+    category: AssociationType
+): List<MockAssociation> {
   return mockAssociations.filter { it.type == category }.sortedBy { it.association.acronym }
 }
 

--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,51 +28,56 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.android.unio.model.association.Association
+import com.android.unio.model.association.AssociationType
+import com.android.unio.model.association.MockAssociation
+import com.android.unio.model.association.mockAssociations
 
 @Composable
 fun ExploreScreen() {
   Scaffold(
+      /**
+       * This is where the bottom navigation bar will be added. For now, it is just a placeholder
+       */
       modifier = Modifier.testTag("exploreScreen"),
-      /** Here, we should have the bottom navigation bar. */
-      content = { padding ->
-        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
-          OutlinedTextField(
-              value = "",
-              onValueChange = {},
-              modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("searchBar"),
-              placeholder = { Text("Search") },
-              trailingIcon = { Icon(Icons.Default.Search, contentDescription = "Search icon") })
+      content = { padding -> ExploreScreenContent(padding) })
+}
 
-          LazyColumn(
-              modifier = Modifier.fillMaxSize(),
-              verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                AssociationType.entries.forEach { category ->
-                  val filteredAssociations =
-                      mockAssociations
-                          .filter { it.type == category }
-                          .sortedBy { it.association.acronym }
+@Composable
+fun ExploreScreenContent(padding: PaddingValues) {
+  // This is a placeholder for the actual content of the Explore screen
+  Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+    OutlinedTextField(
+        value = "",
+        onValueChange = {},
+        modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("searchBar"),
+        placeholder = { Text("Search") },
+        trailingIcon = { Icon(Icons.Default.Search, contentDescription = "Search icon") })
 
-                  if (filteredAssociations.isNotEmpty()) {
-                    item {
-                      Text(
-                          text = category.name.lowercase().replaceFirstChar { it.uppercase() },
-                          fontWeight = FontWeight.Bold,
-                          modifier = Modifier.padding(horizontal = 16.dp).testTag("categoryTitle"))
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+          AssociationType.entries.forEach { category ->
+            val filteredAssociations = getFilteredAssociationsByCategory(category)
 
-                      // Horizontal scrollable list of associations
-                      LazyRow(
-                          modifier = Modifier.fillMaxWidth(),
-                          horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                            items(filteredAssociations.size) { index ->
-                              AssociationItem(filteredAssociations[index].association)
-                            }
-                          }
+            if (filteredAssociations.isNotEmpty()) {
+              item {
+                Text(
+                    text = getCategoryNameWithFirstLetterUppercase(category),
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 16.dp).testTag("categoryTitle"))
+
+                // Horizontal scrollable list of associations
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                      items(filteredAssociations.size) { index ->
+                        AssociationItem(filteredAssociations[index].association)
+                      }
                     }
-                  }
-                }
               }
+            }
+          }
         }
-      })
+  }
 }
 
 @Composable
@@ -99,80 +105,12 @@ fun AssociationItem(association: Association) {
       }
 }
 
-/**
- * Everything below is mock data. This file (and other classes) should later be adapted to get data
- * from the association repository.
- */
-enum class AssociationType {
-  MUSIC,
-  FESTIVALS,
-  INNOVATION,
-  FACULTIES,
-  SOCIAL,
-  TECH,
-  OTHER
+/** Returns a list of associations filtered by the given category. */
+fun getFilteredAssociationsByCategory(category: AssociationType): List<MockAssociation> {
+  return mockAssociations.filter { it.type == category }.sortedBy { it.association.acronym }
 }
 
-data class MockAssociation(val association: Association, val type: AssociationType)
-
-val mockAssociations =
-    listOf(
-        MockAssociation(
-            Association(
-                uid = "1",
-                acronym = "Musical",
-                fullName = "Musical Association",
-                description =
-                    "AGEPoly Commission – stimulation of the practice of music on the campus",
-                members = emptyList()),
-            AssociationType.MUSIC),
-        MockAssociation(
-            Association(
-                uid = "2",
-                acronym = "Nuit De la Magistrale",
-                fullName = "Nuit De la Magistrale Association",
-                description =
-                    "AGEPoly Commission – party following the formal Magistrale Graduation Ceremony",
-                members = emptyList()),
-            AssociationType.FESTIVALS),
-        MockAssociation(
-            Association(
-                uid = "3",
-                acronym = "Balélec",
-                fullName = "Festival Balélec",
-                description = "Open-air unique en Suisse, organisée par des bénévoles étudiants.",
-                members = emptyList()),
-            AssociationType.FESTIVALS),
-        MockAssociation(
-            Association(
-                uid = "4",
-                acronym = "Artiphys",
-                fullName = "Festival Artiphys",
-                description = "Festival à l'EPFL",
-                members = emptyList()),
-            AssociationType.FESTIVALS),
-        MockAssociation(
-            Association(
-                uid = "5",
-                acronym = "Sysmic",
-                fullName = "Festival Sysmic",
-                description = "Festival à l'EPFL",
-                members = emptyList()),
-            AssociationType.FESTIVALS),
-        MockAssociation(
-            Association(
-                uid = "6",
-                acronym = "IFL",
-                fullName = "Innovation Forum Lausanne",
-                description = "Innovation Forum Lausanne",
-                members = emptyList()),
-            AssociationType.INNOVATION),
-        MockAssociation(
-            Association(
-                uid = "7",
-                acronym = "Clic",
-                fullName = "Clic Association",
-                description = "Association of EPFL Students of IC Faculty",
-                members = emptyList()),
-            AssociationType.FACULTIES),
-    )
+/** Returns the name of the category with the first letter in uppercase. */
+fun getCategoryNameWithFirstLetterUppercase(category: AssociationType): String {
+  return category.name.lowercase().replaceFirstChar { it.uppercase() }
+}

--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -14,12 +14,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -30,83 +30,64 @@ import com.android.unio.model.association.Association
 
 @Composable
 fun ExploreScreen() {
-    Scaffold(
-        modifier = Modifier.testTag("exploreScreen"),
-        /**
-         * Here, we should have the bottom navigation bar.
-         */
-        content = { padding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-            ) {
-                OutlinedTextField(
-                    value = "",
-                    onValueChange = {},
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(8.dp)
-                        .testTag("searchBar"),
-                    placeholder = { Text("Search") },
-                    trailingIcon = { Icon(Icons.Default.Search, contentDescription = "Search icon") }
-                )
+  Scaffold(
+      modifier = Modifier.testTag("exploreScreen"),
+      /** Here, we should have the bottom navigation bar. */
+      content = { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+          OutlinedTextField(
+              value = "",
+              onValueChange = {},
+              modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("searchBar"),
+              placeholder = { Text("Search") },
+              trailingIcon = { Icon(Icons.Default.Search, contentDescription = "Search icon") })
 
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    AssociationType.entries.forEach { category ->
-                        val filteredAssociations = mockAssociations
-                            .filter { it.type == category }
-                            .sortedBy { it.association.acronym }
+          LazyColumn(
+              modifier = Modifier.fillMaxSize(),
+              verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                AssociationType.entries.forEach { category ->
+                  val filteredAssociations =
+                      mockAssociations
+                          .filter { it.type == category }
+                          .sortedBy { it.association.acronym }
 
-                        if (filteredAssociations.isNotEmpty()) {
-                            item {
-                                Text(
-                                    text = category.name.lowercase().replaceFirstChar { it.uppercase() },
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier
-                                        .padding(horizontal = 16.dp)
-                                        .testTag("categoryTitle")
-                                )
+                  if (filteredAssociations.isNotEmpty()) {
+                    item {
+                      Text(
+                          text = category.name.lowercase().replaceFirstChar { it.uppercase() },
+                          fontWeight = FontWeight.Bold,
+                          modifier = Modifier.padding(horizontal = 16.dp).testTag("categoryTitle"))
 
-                                // Horizontal scrollable list of associations
-                                LazyRow(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.spacedBy(16.dp)
-                                ) {
-                                    items(filteredAssociations.size) { index ->
-                                        AssociationItem(filteredAssociations[index].association)
-                                    }
-                                }
+                      // Horizontal scrollable list of associations
+                      LazyRow(
+                          modifier = Modifier.fillMaxWidth(),
+                          horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                            items(filteredAssociations.size) { index ->
+                              AssociationItem(filteredAssociations[index].association)
                             }
-                        }
+                          }
                     }
+                  }
                 }
-            }
+              }
         }
-    )
+      })
 }
 
 @Composable
 fun AssociationItem(association: Association) {
-    Column(
-        modifier = Modifier
-            .padding(16.dp)
-            .width(80.dp)
-        // Interaction (to see detailed screen about an association) can be defined here,
-        // with the .clickable modifier
-    ) {
+  Column(
+      modifier = Modifier.padding(16.dp).width(80.dp)
+      // Interaction (to see detailed screen about an association) can be defined here,
+      // with the .clickable modifier
+      ) {
         /**
-         * Placeholder for the image later on when we find a way to get and store them,
-         * for now just a gray box
+         * Placeholder for the image later on when we find a way to get and store them, for now just
+         * a gray box
          */
         Box(
-            modifier = Modifier
-                .size(64.dp)
-                .background(Color.LightGray, shape = RoundedCornerShape(8.dp))
-        )
+            modifier =
+                Modifier.size(64.dp).background(Color.LightGray, shape = RoundedCornerShape(8.dp)))
 
         Spacer(modifier = Modifier.height(8.dp))
 
@@ -114,90 +95,84 @@ fun AssociationItem(association: Association) {
             text = association.acronym,
             fontWeight = FontWeight.Normal,
             modifier = Modifier.fillMaxWidth(),
-            maxLines = 1
-        )
-    }
+            maxLines = 1)
+      }
 }
 
 /**
- * Everything below is mock data. This file (and other classes)
- * should later be adapted to get data from the association repository.
+ * Everything below is mock data. This file (and other classes) should later be adapted to get data
+ * from the association repository.
  */
 enum class AssociationType {
-    MUSIC, FESTIVALS, INNOVATION, FACULTIES, SOCIAL, TECH, OTHER
+  MUSIC,
+  FESTIVALS,
+  INNOVATION,
+  FACULTIES,
+  SOCIAL,
+  TECH,
+  OTHER
 }
 
 data class MockAssociation(val association: Association, val type: AssociationType)
 
-val mockAssociations = listOf(
-    MockAssociation(
-        Association(
-            uid = "1",
-            acronym = "Musical",
-            fullName = "Musical Association",
-            description = "AGEPoly Commission – stimulation of the practice of music on the campus",
-            members = emptyList()
-        ),
-        AssociationType.MUSIC
-    ),
-    MockAssociation(
-        Association(
-            uid = "2",
-            acronym = "Nuit De la Magistrale",
-            fullName = "Nuit De la Magistrale Association",
-            description = "AGEPoly Commission – party following the formal Magistrale Graduation Ceremony",
-            members = emptyList()
-        ),
-        AssociationType.FESTIVALS
-    ),
-    MockAssociation(
-        Association(
-            uid = "3",
-            acronym = "Balélec",
-            fullName = "Festival Balélec",
-            description = "Open-air unique en Suisse, organisée par des bénévoles étudiants.",
-            members = emptyList()
-        ),
-        AssociationType.FESTIVALS
-    ),
-    MockAssociation(
-        Association(
-            uid = "4",
-            acronym = "Artiphys",
-            fullName = "Festival Artiphys",
-            description = "Festival à l'EPFL",
-            members = emptyList()
-        ),
-        AssociationType.FESTIVALS
-    ),
-    MockAssociation(
-        Association(
-            uid = "5",
-            acronym = "Sysmic",
-            fullName = "Festival Sysmic",
-            description = "Festival à l'EPFL",
-            members = emptyList()
-        ),
-        AssociationType.FESTIVALS
-    ),
-    MockAssociation(
-        Association(
-            uid = "6",
-            acronym = "IFL",
-            fullName = "Innovation Forum Lausanne",
-            description = "Innovation Forum Lausanne",
-            members = emptyList()
-        ),
-        AssociationType.INNOVATION
-    ),
-    MockAssociation(
-        Association(
-            uid = "7",
-            acronym = "Clic",
-            fullName = "Clic Association",
-            description = "Association of EPFL Students of IC Faculty",
-            members = emptyList()
-        ),
-        AssociationType.FACULTIES
-    ),
-)
+val mockAssociations =
+    listOf(
+        MockAssociation(
+            Association(
+                uid = "1",
+                acronym = "Musical",
+                fullName = "Musical Association",
+                description =
+                    "AGEPoly Commission – stimulation of the practice of music on the campus",
+                members = emptyList()),
+            AssociationType.MUSIC),
+        MockAssociation(
+            Association(
+                uid = "2",
+                acronym = "Nuit De la Magistrale",
+                fullName = "Nuit De la Magistrale Association",
+                description =
+                    "AGEPoly Commission – party following the formal Magistrale Graduation Ceremony",
+                members = emptyList()),
+            AssociationType.FESTIVALS),
+        MockAssociation(
+            Association(
+                uid = "3",
+                acronym = "Balélec",
+                fullName = "Festival Balélec",
+                description = "Open-air unique en Suisse, organisée par des bénévoles étudiants.",
+                members = emptyList()),
+            AssociationType.FESTIVALS),
+        MockAssociation(
+            Association(
+                uid = "4",
+                acronym = "Artiphys",
+                fullName = "Festival Artiphys",
+                description = "Festival à l'EPFL",
+                members = emptyList()),
+            AssociationType.FESTIVALS),
+        MockAssociation(
+            Association(
+                uid = "5",
+                acronym = "Sysmic",
+                fullName = "Festival Sysmic",
+                description = "Festival à l'EPFL",
+                members = emptyList()),
+            AssociationType.FESTIVALS),
+        MockAssociation(
+            Association(
+                uid = "6",
+                acronym = "IFL",
+                fullName = "Innovation Forum Lausanne",
+                description = "Innovation Forum Lausanne",
+                members = emptyList()),
+            AssociationType.INNOVATION),
+        MockAssociation(
+            Association(
+                uid = "7",
+                acronym = "Clic",
+                fullName = "Clic Association",
+                description = "Association of EPFL Students of IC Faculty",
+                members = emptyList()),
+            AssociationType.FACULTIES),
+    )


### PR DESCRIPTION
Things that still need to be implemented:

- [ ] Interactions
        - [ ]  Clicking on an association brings us to their association profile (with a back button available).
        - [ ]  Typing in the search bar should display all accordingly filtered associations, in a simple column lazy list, where the items will show up in a small height but take the screen's width (just like common search suggestions in most applications that we use).
        - [ ] Bottom navigation bar needs to be added.

- [ ] Data queries (can be done later in a different PR)
        - [ ] The explore view model should be used, and use its list that gets the data directly form the firebase database.
        - [ ] A way to fetch their logo and display them instead of the gray box.

- [ ] Design (can be done later in a different PR)
        - [ ] Actual design that's more accurate to the figma when it is finalized. This includes positioning, fonts and colors.