### PR TITLE
chore(association): add generic functions to the repository of the associations.

### DIFF
--- a/app/src/main/java/com/android/unio/model/association/AssociationRepository.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationRepository.kt
@@ -10,4 +10,10 @@ interface AssociationRepository {
       onSuccess: (Association) -> Unit,
       onFailure: (Exception) -> Unit
   )
+
+  fun addAssociation(association: Association, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  fun updateAssociation(association: Association, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  fun deleteAssociationById(associationId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 }

--- a/app/src/main/java/com/android/unio/model/association/AssociationRepository.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationRepository.kt
@@ -11,9 +11,21 @@ interface AssociationRepository {
       onFailure: (Exception) -> Unit
   )
 
-  fun addAssociation(association: Association, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+  fun addAssociation(
+      association: Association,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 
-  fun updateAssociation(association: Association, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+  fun updateAssociation(
+      association: Association,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 
-  fun deleteAssociationById(associationId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+  fun deleteAssociationById(
+      associationId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 }

--- a/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
@@ -1,12 +1,15 @@
 package com.android.unio.model.association
 
+import android.util.Log
 import com.android.unio.model.firestore.FirestorePaths.ASSOCIATION_PATH
 import com.android.unio.model.firestore.FirestorePaths.USER_PATH
 import com.android.unio.model.firestore.FirestoreReferenceList
 import com.android.unio.model.user.UserRepositoryFirestore
+import com.google.android.gms.tasks.Task
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 
 class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : AssociationRepository {
@@ -51,6 +54,59 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
         }
         .addOnFailureListener { exception -> onFailure(exception) }
   }
+
+    override fun addAssociation(
+        association: Association,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        performFirestoreOperation(
+            db.collection(ASSOCIATION_PATH).document(association.uid).set(association),
+            onSuccess,
+            onFailure)
+    }
+
+    override fun updateAssociation(
+        association: Association,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        performFirestoreOperation(
+            db.collection(ASSOCIATION_PATH).document(association.uid).set(association),
+            onSuccess,
+            onFailure)
+    }
+
+    override fun deleteAssociationById(
+        associationId: String,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        performFirestoreOperation(
+            db.collection(ASSOCIATION_PATH).document(associationId).delete(),
+            onSuccess,
+            onFailure)
+    }
+
+    /**
+     * Performs a Firestore operation and calls the appropriate callback based on the result.
+     */
+    private fun performFirestoreOperation(
+        task: Task<Void>,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        task.addOnCompleteListener {
+            if (it.isSuccessful) {
+                onSuccess()
+            } else {
+                it.exception?.let { e ->
+                    Log.e("AssociationRepositoryFirestore", "Error performing Firestore operation", e)
+                    onFailure(e)
+                }
+            }
+        }
+    }
 
   companion object {
     fun hydrate(doc: DocumentSnapshot): Association {

--- a/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
@@ -9,7 +9,6 @@ import com.google.android.gms.tasks.Task
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
-import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 
 class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : AssociationRepository {
@@ -55,58 +54,54 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
         .addOnFailureListener { exception -> onFailure(exception) }
   }
 
-    override fun addAssociation(
-        association: Association,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        performFirestoreOperation(
-            db.collection(ASSOCIATION_PATH).document(association.uid).set(association),
-            onSuccess,
-            onFailure)
-    }
+  override fun addAssociation(
+      association: Association,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    performFirestoreOperation(
+        db.collection(ASSOCIATION_PATH).document(association.uid).set(association),
+        onSuccess,
+        onFailure)
+  }
 
-    override fun updateAssociation(
-        association: Association,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        performFirestoreOperation(
-            db.collection(ASSOCIATION_PATH).document(association.uid).set(association),
-            onSuccess,
-            onFailure)
-    }
+  override fun updateAssociation(
+      association: Association,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    performFirestoreOperation(
+        db.collection(ASSOCIATION_PATH).document(association.uid).set(association),
+        onSuccess,
+        onFailure)
+  }
 
-    override fun deleteAssociationById(
-        associationId: String,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        performFirestoreOperation(
-            db.collection(ASSOCIATION_PATH).document(associationId).delete(),
-            onSuccess,
-            onFailure)
-    }
+  override fun deleteAssociationById(
+      associationId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    performFirestoreOperation(
+        db.collection(ASSOCIATION_PATH).document(associationId).delete(), onSuccess, onFailure)
+  }
 
-    /**
-     * Performs a Firestore operation and calls the appropriate callback based on the result.
-     */
-    private fun performFirestoreOperation(
-        task: Task<Void>,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        task.addOnCompleteListener {
-            if (it.isSuccessful) {
-                onSuccess()
-            } else {
-                it.exception?.let { e ->
-                    Log.e("AssociationRepositoryFirestore", "Error performing Firestore operation", e)
-                    onFailure(e)
-                }
-            }
+  /** Performs a Firestore operation and calls the appropriate callback based on the result. */
+  private fun performFirestoreOperation(
+      task: Task<Void>,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    task.addOnCompleteListener {
+      if (it.isSuccessful) {
+        onSuccess()
+      } else {
+        it.exception?.let { e ->
+          Log.e("AssociationRepositoryFirestore", "Error performing Firestore operation", e)
+          onFailure(e)
         }
+      }
     }
+  }
 
   companion object {
     fun hydrate(doc: DocumentSnapshot): Association {

--- a/app/src/test/java/com/android/unio/model/association/AssociationRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/unio/model/association/AssociationRepositoryFirestoreTest.kt
@@ -6,6 +6,7 @@ import com.android.unio.model.firestore.FirestoreReferenceList
 import com.android.unio.model.user.UserRepositoryFirestore
 import com.google.android.gms.tasks.OnSuccessListener
 import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
@@ -22,6 +23,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -168,4 +170,82 @@ class AssociationRepositoryFirestoreTest {
         },
         onFailure = { exception -> assert(false) })
   }
+
+    @Test
+    fun testAddAssociationSuccess() {
+        `when`(documentReference.set(association1)).thenReturn(Tasks.forResult(null))
+
+        repository.addAssociation(
+            association1,
+            onSuccess = { assert(true) },
+            onFailure = { assert(false) }
+        )
+
+        verify(documentReference).set(association1)
+    }
+
+    @Test
+    fun testAddAssociationFailure() {
+        `when`(documentReference.set(association1)).thenReturn(Tasks.forException(Exception()))
+
+        repository.addAssociation(
+            association1,
+            onSuccess = { assert(false) },
+            onFailure = { assert(true) }
+        )
+
+        verify(documentReference).set(association1)
+    }
+
+    @Test
+    fun testUpdateAssociationSuccess() {
+        `when`(documentReference.set(association1)).thenReturn(Tasks.forResult(null))
+
+        repository.updateAssociation(
+            association1,
+            onSuccess = { assert(true) },
+            onFailure = { assert(false) }
+        )
+
+        verify(documentReference).set(association1)
+    }
+
+    @Test
+    fun testUpdateAssociationFailure() {
+        `when`(documentReference.set(association1)).thenReturn(Tasks.forException(Exception()))
+
+        repository.updateAssociation(
+            association1,
+            onSuccess = { assert(false) },
+            onFailure = { assert(true) }
+        )
+
+        verify(documentReference).set(association1)
+    }
+
+    @Test
+    fun testDeleteAssociationByIdSuccess() {
+        `when`(documentReference.delete()).thenReturn(Tasks.forResult(null))
+
+        repository.deleteAssociationById(
+            association1.uid,
+            onSuccess = { assert(true) },
+            onFailure = { assert(false) }
+        )
+
+        verify(documentReference).delete()
+    }
+
+    @Test
+    fun testDeleteAssociationByIdFailure() {
+        `when`(documentReference.delete()).thenReturn(Tasks.forException(Exception()))
+
+        repository.deleteAssociationById(
+            association1.uid,
+            onSuccess = { assert(false) },
+            onFailure = { assert(true) }
+        )
+
+        verify(documentReference).delete()
+    }
 }

--- a/app/src/test/java/com/android/unio/model/association/AssociationRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/unio/model/association/AssociationRepositoryFirestoreTest.kt
@@ -171,81 +171,63 @@ class AssociationRepositoryFirestoreTest {
         onFailure = { exception -> assert(false) })
   }
 
-    @Test
-    fun testAddAssociationSuccess() {
-        `when`(documentReference.set(association1)).thenReturn(Tasks.forResult(null))
+  @Test
+  fun testAddAssociationSuccess() {
+    `when`(documentReference.set(association1)).thenReturn(Tasks.forResult(null))
 
-        repository.addAssociation(
-            association1,
-            onSuccess = { assert(true) },
-            onFailure = { assert(false) }
-        )
+    repository.addAssociation(
+        association1, onSuccess = { assert(true) }, onFailure = { assert(false) })
 
-        verify(documentReference).set(association1)
-    }
+    verify(documentReference).set(association1)
+  }
 
-    @Test
-    fun testAddAssociationFailure() {
-        `when`(documentReference.set(association1)).thenReturn(Tasks.forException(Exception()))
+  @Test
+  fun testAddAssociationFailure() {
+    `when`(documentReference.set(association1)).thenReturn(Tasks.forException(Exception()))
 
-        repository.addAssociation(
-            association1,
-            onSuccess = { assert(false) },
-            onFailure = { assert(true) }
-        )
+    repository.addAssociation(
+        association1, onSuccess = { assert(false) }, onFailure = { assert(true) })
 
-        verify(documentReference).set(association1)
-    }
+    verify(documentReference).set(association1)
+  }
 
-    @Test
-    fun testUpdateAssociationSuccess() {
-        `when`(documentReference.set(association1)).thenReturn(Tasks.forResult(null))
+  @Test
+  fun testUpdateAssociationSuccess() {
+    `when`(documentReference.set(association1)).thenReturn(Tasks.forResult(null))
 
-        repository.updateAssociation(
-            association1,
-            onSuccess = { assert(true) },
-            onFailure = { assert(false) }
-        )
+    repository.updateAssociation(
+        association1, onSuccess = { assert(true) }, onFailure = { assert(false) })
 
-        verify(documentReference).set(association1)
-    }
+    verify(documentReference).set(association1)
+  }
 
-    @Test
-    fun testUpdateAssociationFailure() {
-        `when`(documentReference.set(association1)).thenReturn(Tasks.forException(Exception()))
+  @Test
+  fun testUpdateAssociationFailure() {
+    `when`(documentReference.set(association1)).thenReturn(Tasks.forException(Exception()))
 
-        repository.updateAssociation(
-            association1,
-            onSuccess = { assert(false) },
-            onFailure = { assert(true) }
-        )
+    repository.updateAssociation(
+        association1, onSuccess = { assert(false) }, onFailure = { assert(true) })
 
-        verify(documentReference).set(association1)
-    }
+    verify(documentReference).set(association1)
+  }
 
-    @Test
-    fun testDeleteAssociationByIdSuccess() {
-        `when`(documentReference.delete()).thenReturn(Tasks.forResult(null))
+  @Test
+  fun testDeleteAssociationByIdSuccess() {
+    `when`(documentReference.delete()).thenReturn(Tasks.forResult(null))
 
-        repository.deleteAssociationById(
-            association1.uid,
-            onSuccess = { assert(true) },
-            onFailure = { assert(false) }
-        )
+    repository.deleteAssociationById(
+        association1.uid, onSuccess = { assert(true) }, onFailure = { assert(false) })
 
-        verify(documentReference).delete()
-    }
+    verify(documentReference).delete()
+  }
 
-    @Test
-    fun testDeleteAssociationByIdFailure() {
-        `when`(documentReference.delete()).thenReturn(Tasks.forException(Exception()))
+  @Test
+  fun testDeleteAssociationByIdFailure() {
+    `when`(documentReference.delete()).thenReturn(Tasks.forException(Exception()))
 
-        repository.deleteAssociationById(
-            association1.uid,
-            onSuccess = { assert(false) },
-            onFailure = { assert(true) }
-        )
+    repository.deleteAssociationById(
+        association1.uid, onSuccess = { assert(false) }, onFailure = { assert(true) })
 
-        verify(documentReference).delete()
-    }
+    verify(documentReference).delete()
+  }
 }


### PR DESCRIPTION
This includes:

- A general function which is used to perform a Firestore operation and call the appropriate callback based on the result
- An add function, that adds a new association to the Firestore database.
- An update function, which updates an existing association in the Firestore database.
- A delete function (by Id), which deletes an association from the Firestore database.

This will be useful when a new association signs-up to our service or modifies some of its data. I added a delete function in case some associations dissolves or leaves our service.