### PR TITLE
chore(explore): change height of association item for demo

### DIFF
--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -93,7 +93,7 @@ fun ExploreScreenContent(padding: PaddingValues, navigationAction: NavigationAct
 fun AssociationItem(association: Association, navigationAction: NavigationAction) {
   Column(
       modifier =
-          Modifier.padding(16.dp).width(80.dp).clickable {
+          Modifier.padding(16.dp).width(80.dp).height(120.dp).clickable {
             navigationAction.navigateTo(Screen.ASSOCIATION)
           }
       // Interaction (to see detailed screen about an association) can be defined here,


### PR DESCRIPTION
This is simply to show, during the S1 demo, that we can scroll vertically through the association categories.
The height increase will allow the lazy list to have enough height such that we have to scroll so see the last category.