### PR TITLE
fix(model/image): upload image

### DIFF
--- a/app/src/main/java/com/android/unio/model/image/ImageRepository.kt
+++ b/app/src/main/java/com/android/unio/model/image/ImageRepository.kt
@@ -1,15 +1,13 @@
 package com.android.unio.model.image
 
-import com.google.firebase.storage.UploadTask.TaskSnapshot
 import java.io.InputStream
 
 interface ImageRepository {
-  fun getImageUrl(firebasePath: String, onSuccess: (String) -> Unit, onFailure: (Exception) -> Unit)
 
   fun uploadImage(
       imageStream: InputStream,
       firebasePath: String,
-      onSuccess: (TaskSnapshot) -> Unit,
+      onSuccess: (String) -> Unit,
       onFailure: (Exception) -> Unit
   )
 }

--- a/app/src/main/java/com/android/unio/model/image/ImageRepositoryFirebaseStorage.kt
+++ b/app/src/main/java/com/android/unio/model/image/ImageRepositoryFirebaseStorage.kt
@@ -1,7 +1,6 @@
 package com.android.unio.model.image
 
 import com.google.firebase.storage.FirebaseStorage
-import com.google.firebase.storage.UploadTask.TaskSnapshot
 import java.io.InputStream
 
 class ImageRepositoryFirebaseStorage(
@@ -10,7 +9,8 @@ class ImageRepositoryFirebaseStorage(
 
   private val storageRef = storage.reference
 
-  override fun getImageUrl(
+    /** Helper function that gets the downloadUrl of an image. Is used after calling uploadImage. */
+    private fun getImageUrl(
       firebasePath: String,
       onSuccess: (String) -> Unit,
       onFailure: (Exception) -> Unit
@@ -22,16 +22,20 @@ class ImageRepositoryFirebaseStorage(
         .addOnFailureListener { e -> onFailure(e) }
   }
 
+    /** Uploads an image stream to Firebase Storage. Gives a downloadUrl to onSuccess. */
   override fun uploadImage(
       imageStream: InputStream,
       firebasePath: String,
-      onSuccess: (TaskSnapshot) -> Unit,
+      onSuccess: (String) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    val uploadTask = storageRef.child(firebasePath).putStream(imageStream)
+        val path = storageRef.child(firebasePath)
+        val uploadTask = path.putStream(imageStream)
 
     uploadTask
-        .addOnSuccessListener { taskSnapshot -> onSuccess(taskSnapshot) }
+        .addOnSuccessListener {
+            getImageUrl(firebasePath, onSuccess = onSuccess, onFailure = onFailure)
+        }
         .addOnFailureListener { exception -> onFailure(exception) }
   }
 }

--- a/app/src/main/java/com/android/unio/model/image/ImageRepositoryFirebaseStorage.kt
+++ b/app/src/main/java/com/android/unio/model/image/ImageRepositoryFirebaseStorage.kt
@@ -9,8 +9,8 @@ class ImageRepositoryFirebaseStorage(
 
   private val storageRef = storage.reference
 
-    /** Helper function that gets the downloadUrl of an image. Is used after calling uploadImage. */
-    private fun getImageUrl(
+  /** Helper function that gets the downloadUrl of an image. Is used after calling uploadImage. */
+  private fun getImageUrl(
       firebasePath: String,
       onSuccess: (String) -> Unit,
       onFailure: (Exception) -> Unit
@@ -22,19 +22,19 @@ class ImageRepositoryFirebaseStorage(
         .addOnFailureListener { e -> onFailure(e) }
   }
 
-    /** Uploads an image stream to Firebase Storage. Gives a downloadUrl to onSuccess. */
+  /** Uploads an image stream to Firebase Storage. Gives a downloadUrl to onSuccess. */
   override fun uploadImage(
       imageStream: InputStream,
       firebasePath: String,
       onSuccess: (String) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-        val path = storageRef.child(firebasePath)
-        val uploadTask = path.putStream(imageStream)
+    val path = storageRef.child(firebasePath)
+    val uploadTask = path.putStream(imageStream)
 
     uploadTask
         .addOnSuccessListener {
-            getImageUrl(firebasePath, onSuccess = onSuccess, onFailure = onFailure)
+          getImageUrl(firebasePath, onSuccess = onSuccess, onFailure = onFailure)
         }
         .addOnFailureListener { exception -> onFailure(exception) }
   }

--- a/app/src/test/java/com/android/unio/model/image/ImageRepositoryFirebaseStorageTest.kt
+++ b/app/src/test/java/com/android/unio/model/image/ImageRepositoryFirebaseStorageTest.kt
@@ -58,17 +58,12 @@ class ImageRepositoryFirebaseStorageTest {
   }
 
   /**
-   * Asserts that getImageUrl calls the right functions and returns a string that can be converted
+   * Asserts that uploadImage calls the right functions and returns a string that can be converted
    * to Uri format.
    */
   @Test
-  fun getImageUrlTest() {
-    repository.getImageUrl("images/test.jpg", { stringUrl -> stringUrl.toUri() }, { e -> throw e })
-  }
-
-  /** Asserts that uploadImage calls the right functions. */
-  @Test
   fun uploadImageTest() {
-    repository.uploadImage(fileInputStream, "images/test.jpg", {}, {})
+    repository.uploadImage(
+        fileInputStream, "images/test.jpg", { stringUrl -> stringUrl.toUri() }, { e -> throw e })
   }
 }


### PR DESCRIPTION
Fix uploadImage so it outputs the image's download link automatically.
Set the getDownloadUrl as private because it shouldn't be used elsewhere in the project.
Also added some comments to the methods.