### PR TITLE
chore(association): refactor association repository with universal function

### DIFF
--- a/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
@@ -26,18 +26,19 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
       onSuccess: (List<Association>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    db.collection(ASSOCIATION_PATH)
-        .get()
-        .addOnSuccessListener { result ->
-          val associations = mutableListOf<Association>()
-          for (document in result) {
-            val association = hydrate(document)
+      performFirestoreOperation(
+          db.collection(ASSOCIATION_PATH).get(),
+          onSuccess = { result ->
+              val associations = mutableListOf<Association>()
+              for (document in result) {
+                  val association = hydrate(document)
 
-            associations.add(association)
-          }
-          onSuccess(associations)
-        }
-        .addOnFailureListener { exception -> onFailure(exception) }
+                  associations.add(association)
+              }
+              onSuccess(associations)
+          },
+          onFailure = { exception -> onFailure(exception) }
+      )
   }
 
   override fun getAssociationWithId(
@@ -45,14 +46,11 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
       onSuccess: (Association) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    db.collection(ASSOCIATION_PATH)
-        .document(id)
-        .get()
-        .addOnSuccessListener { document ->
-          val association = hydrate(document)
-          onSuccess(association)
-        }
-        .addOnFailureListener { exception -> onFailure(exception) }
+      performFirestoreOperation(
+          db.collection(ASSOCIATION_PATH).document(id).get(),
+          onSuccess = { document -> onSuccess(hydrate(document)) },
+          onFailure = { exception -> onFailure(exception) }
+      )
   }
 
   override fun addAssociation(
@@ -62,7 +60,7 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
   ) {
     performFirestoreOperation(
         db.collection(ASSOCIATION_PATH).document(association.uid).set(association),
-        onSuccess,
+        onSuccess = { onSuccess() },
         onFailure)
   }
 
@@ -73,7 +71,7 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
   ) {
     performFirestoreOperation(
         db.collection(ASSOCIATION_PATH).document(association.uid).set(association),
-        onSuccess,
+        onSuccess = { onSuccess() },
         onFailure)
   }
 
@@ -83,18 +81,23 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
       onFailure: (Exception) -> Unit
   ) {
     performFirestoreOperation(
-        db.collection(ASSOCIATION_PATH).document(associationId).delete(), onSuccess, onFailure)
+        db.collection(ASSOCIATION_PATH).document(associationId).delete(),
+        onSuccess = { onSuccess() },
+        onFailure)
   }
 
+
+
+
   /** Performs a Firestore operation and calls the appropriate callback based on the result. */
-  private fun performFirestoreOperation(
-      task: Task<Void>,
-      onSuccess: () -> Unit,
+  private fun <T> performFirestoreOperation(
+      task: Task<T>,
+      onSuccess: (T) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
     task.addOnCompleteListener {
       if (it.isSuccessful) {
-        onSuccess()
+        it.result?.let { result -> onSuccess(result) }
       } else {
         it.exception?.let { e ->
           Log.e("AssociationRepositoryFirestore", "Error performing Firestore operation", e)

--- a/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationRepositoryFirestore.kt
@@ -26,19 +26,18 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
       onSuccess: (List<Association>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-      performFirestoreOperation(
-          db.collection(ASSOCIATION_PATH).get(),
-          onSuccess = { result ->
-              val associations = mutableListOf<Association>()
-              for (document in result) {
-                  val association = hydrate(document)
+    performFirestoreOperation(
+        db.collection(ASSOCIATION_PATH).get(),
+        onSuccess = { result ->
+          val associations = mutableListOf<Association>()
+          for (document in result) {
+            val association = hydrate(document)
 
-                  associations.add(association)
-              }
-              onSuccess(associations)
-          },
-          onFailure = { exception -> onFailure(exception) }
-      )
+            associations.add(association)
+          }
+          onSuccess(associations)
+        },
+        onFailure = { exception -> onFailure(exception) })
   }
 
   override fun getAssociationWithId(
@@ -46,11 +45,10 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
       onSuccess: (Association) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-      performFirestoreOperation(
-          db.collection(ASSOCIATION_PATH).document(id).get(),
-          onSuccess = { document -> onSuccess(hydrate(document)) },
-          onFailure = { exception -> onFailure(exception) }
-      )
+    performFirestoreOperation(
+        db.collection(ASSOCIATION_PATH).document(id).get(),
+        onSuccess = { document -> onSuccess(hydrate(document)) },
+        onFailure = { exception -> onFailure(exception) })
   }
 
   override fun addAssociation(
@@ -85,9 +83,6 @@ class AssociationRepositoryFirestore(private val db: FirebaseFirestore) : Associ
         onSuccess = { onSuccess() },
         onFailure)
   }
-
-
-
 
   /** Performs a Firestore operation and calls the appropriate callback based on the result. */
   private fun <T> performFirestoreOperation(


### PR DESCRIPTION
This update enhances the quality of our code:
- It can still handles the simple functions like `addAssociation`, `updateAssociation` and `deleteAssociation`, that use a simple `() -> Unit` typed `onSuccess` function.
- It now supports functions where their `onSuccess` function might require a different input type. This includes the `getAssociations` and `getAssociationWithId` functions.