### PR TITLE
chore(action/apk-maker): add a yml file that should make apk of the main automatically

### DIFF
--- a/.github/workflows/apk-maker.yml
+++ b/.github/workflows/apk-maker.yml
@@ -1,0 +1,40 @@
+name: APK Maker
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  apk:
+    name: Generate Debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 1.8
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Assemble app debug APK
+        run: bash ./gradlew assembleDebug --stacktrace
+
+      - name: Upload app APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
To be able to download the apk of the app directly from GitHub, a workflow is needed to be setup. This is the purpose of this PR. It includes : 

- A apk-maker.yml file that will be useful to setup the Workflow
