### PR TITLE
test: Write additional tests to increase code coverage for AssociationProfile

### DIFF
--- a/.github/workflows/apk-maker.yml
+++ b/.github/workflows/apk-maker.yml
@@ -1,0 +1,40 @@
+name: APK Maker
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  apk:
+    name: Generate Debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 1.8
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Assemble app debug APK
+        run: bash ./gradlew assembleDebug --stacktrace
+
+      - name: Upload app APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
@@ -122,6 +122,14 @@ class AssociationProfileTest {
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationContactMembersCard"))
     composeTestRule.onNodeWithTag("AssociationContactMembersCard").performClick()
     assertSnackBarIsDisplayed()
+
+    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationTreasurerRoles"))
+    composeTestRule.onNodeWithTag("AssociationTreasurerRoles").performClick()
+    assertSnackBarIsDisplayed()
+
+    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationDesignerRoles"))
+    composeTestRule.onNodeWithTag("AssociationDesignerRoles").performClick()
+    assertSnackBarIsDisplayed()
   }
 
   private fun assertSnackBarIsDisplayed() {

--- a/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
@@ -2,6 +2,8 @@ package com.android.unio.ui.association
 
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -19,6 +21,7 @@ import com.android.unio.model.user.UserRepositoryFirestore
 import com.android.unio.ui.navigation.NavigationAction
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.FirebaseFirestore
+import java.lang.Thread.sleep
 import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -79,6 +82,7 @@ class AssociationProfileTest {
 
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationImageHeader"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationProfileTitle"))
+    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("associationShareButton"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationHeaderFollowers"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationHeaderMembers"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationFollowButton"))
@@ -98,6 +102,32 @@ class AssociationProfileTest {
       compose.performScrollTo()
     }
     compose.assertIsDisplayed()
+  }
+
+  @Test
+  fun testButtonBehavior() {
+    composeTestRule.setContent {
+      AssociationProfileScreen(navigationAction, "", associationViewModel)
+    }
+    composeTestRule.onNodeWithTag("associationShareButton").performClick()
+    assertSnackBarIsDisplayed()
+    composeTestRule.onNodeWithTag("AssociationFollowButton").performClick()
+    assertSnackBarIsDisplayed()
+    composeTestRule.onNodeWithTag("AssociationSeeMoreButton").performClick()
+    assertSnackBarIsDisplayed()
+    composeTestRule.onNodeWithTag("AssociationContactMembersCard").performClick()
+    assertSnackBarIsDisplayed()
+  }
+
+  private fun assertSnackBarIsDisplayed() {
+    composeTestRule.onNodeWithTag("associationSnackbarHost").assertIsDisplayed()
+    var thresh = 0
+    while (composeTestRule.onNodeWithTag("associationSnackbarHost").isDisplayed() || thresh < 10) {
+      composeTestRule.onNodeWithTag("snackbarActionButton").performClick()
+      sleep(1000)
+      thresh++
+    }
+    composeTestRule.onNodeWithTag("associationSnackbarHost").assertIsNotDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
@@ -107,12 +107,19 @@ class AssociationProfileTest {
     composeTestRule.setContent {
       AssociationProfileScreen(navigationAction, "", associationViewModel)
     }
+    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("associationShareButton"))
     composeTestRule.onNodeWithTag("associationShareButton").performClick()
     assertSnackBarIsDisplayed()
+
+    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationFollowButton"))
     composeTestRule.onNodeWithTag("AssociationFollowButton").performClick()
     assertSnackBarIsDisplayed()
+
+    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationSeeMoreButton"))
     composeTestRule.onNodeWithTag("AssociationSeeMoreButton").performClick()
     assertSnackBarIsDisplayed()
+
+    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationContactMembersCard"))
     composeTestRule.onNodeWithTag("AssociationContactMembersCard").performClick()
     assertSnackBarIsDisplayed()
   }

--- a/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
@@ -3,7 +3,6 @@ package com.android.unio.ui.association
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -21,7 +20,6 @@ import com.android.unio.model.user.UserRepositoryFirestore
 import com.android.unio.ui.navigation.NavigationAction
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.FirebaseFirestore
-import java.lang.Thread.sleep
 import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -121,12 +119,7 @@ class AssociationProfileTest {
 
   private fun assertSnackBarIsDisplayed() {
     composeTestRule.onNodeWithTag("associationSnackbarHost").assertIsDisplayed()
-    var thresh = 0
-    while (composeTestRule.onNodeWithTag("associationSnackbarHost").isDisplayed() || thresh < 10) {
-      composeTestRule.onNodeWithTag("snackbarActionButton").performClick()
-      sleep(1000)
-      thresh++
-    }
+    composeTestRule.onNodeWithTag("snackbarActionButton").performClick()
     composeTestRule.onNodeWithTag("associationSnackbarHost").assertIsNotDisplayed()
   }
 

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -198,6 +198,7 @@ fun AssociationRecruitment(context: Context) {
   Spacer(modifier = Modifier.size(18.dp))
   Row(modifier = Modifier.padding(horizontal = 24.dp).testTag("AssociationRecruitmentRoles")) {
     OutlinedButton(
+        modifier = Modifier.testTag("AssociationDesignerRoles"),
         onClick = {
           scope!!.launch {
             testSnackbar!!.showSnackbar(message = DEBUG_MESSAGE, duration = SnackbarDuration.Short)
@@ -210,6 +211,7 @@ fun AssociationRecruitment(context: Context) {
         }
     Spacer(modifier = Modifier.width(10.dp))
     OutlinedButton(
+        modifier = Modifier.testTag("AssociationTreasurerRoles"),
         onClick = {
           scope!!.launch {
             testSnackbar!!.showSnackbar(message = DEBUG_MESSAGE, duration = SnackbarDuration.Short)

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -3,7 +3,6 @@ package com.android.unio.ui.association
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -32,9 +31,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -52,6 +58,15 @@ import com.android.unio.resources.ResourceManager.getString
 import com.android.unio.resources.ResourceManager.init
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.theme.AppTypography
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+// These variable are only here for testing purpose. They should be deleted when the screen is
+// linked to the backend
+private val DEBUG_MESSAGE = "<DEBUG> Not implemented yet"
+
+private var testSnackbar: SnackbarHostState? = null
+private var scope: CoroutineScope? = null
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -93,7 +108,7 @@ fun AssociationProfileScreen(
  * @param navigationAction The navigation action to use when the back button is clicked.
  * @param content The content of the screen.
  */
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter", "RememberReturnType")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AssociationProfileScaffold(
@@ -102,8 +117,24 @@ fun AssociationProfileScaffold(
     content: @Composable (padding: PaddingValues) -> Unit
 ) {
   val context = LocalContext.current
+  testSnackbar = remember { SnackbarHostState() }
+  scope = rememberCoroutineScope()
   init(context)
   Scaffold(
+      snackbarHost = {
+        SnackbarHost(
+            hostState = testSnackbar!!,
+            modifier = Modifier.testTag("associationSnackbarHost"),
+            snackbar = { data ->
+              Snackbar {
+                TextButton(
+                    onClick = { testSnackbar!!.currentSnackbarData?.dismiss() },
+                    modifier = Modifier.testTag("snackbarActionButton")) {
+                      Text(text = DEBUG_MESSAGE)
+                    }
+              }
+            })
+      },
       topBar = {
         TopAppBar(
             title = { Text(title, modifier = Modifier.testTag("AssociationProfileTitle")) },
@@ -118,9 +149,12 @@ fun AssociationProfileScaffold(
             },
             actions = {
               IconButton(
+                  modifier = Modifier.testTag("associationShareButton"),
                   onClick = {
-                    Toast.makeText(context, "<DEBUG> Not implemented yet", Toast.LENGTH_SHORT)
-                        .show()
+                    scope!!.launch {
+                      testSnackbar!!.showSnackbar(
+                          message = DEBUG_MESSAGE, duration = SnackbarDuration.Short)
+                    }
                   }) {
                     Icon(Icons.Outlined.Share, contentDescription = "Icon for sharing association")
                   }
@@ -165,7 +199,9 @@ fun AssociationRecruitment(context: Context) {
   Row(modifier = Modifier.padding(horizontal = 24.dp).testTag("AssociationRecruitmentRoles")) {
     OutlinedButton(
         onClick = {
-          Toast.makeText(context, "<DEBUG> Not implemented yet", Toast.LENGTH_SHORT).show()
+          scope!!.launch {
+            testSnackbar!!.showSnackbar(message = DEBUG_MESSAGE, duration = SnackbarDuration.Short)
+          }
         },
         enabled = true) {
           Icon(Icons.Filled.Add, contentDescription = "Add icon")
@@ -175,7 +211,9 @@ fun AssociationRecruitment(context: Context) {
     Spacer(modifier = Modifier.width(10.dp))
     OutlinedButton(
         onClick = {
-          Toast.makeText(context, "<DEBUG> Not implemented yet", Toast.LENGTH_SHORT).show()
+          scope!!.launch {
+            testSnackbar!!.showSnackbar(message = DEBUG_MESSAGE, duration = SnackbarDuration.Short)
+          }
         },
         enabled = true) {
           Icon(Icons.Filled.Add, contentDescription = "Add icon")
@@ -201,7 +239,10 @@ fun UserCard(context: Context) {
               .background(Color.LightGray, RoundedCornerShape(12.dp))
               .padding(vertical = 2.dp, horizontal = 3.dp)
               .clickable {
-                Toast.makeText(context, "<DEBUG> Not implemented yet", Toast.LENGTH_SHORT).show()
+                scope!!.launch {
+                  testSnackbar!!.showSnackbar(
+                      message = DEBUG_MESSAGE, duration = SnackbarDuration.Short)
+                }
               },
   ) {
     Row(
@@ -229,7 +270,10 @@ fun AssociationProfileEvents(context: Context) {
         Spacer(modifier = Modifier.size(11.dp))
         OutlinedButton(
             onClick = {
-              Toast.makeText(context, "<DEBUG> Not implemented yet", Toast.LENGTH_SHORT).show()
+              scope!!.launch {
+                testSnackbar!!.showSnackbar(
+                    message = DEBUG_MESSAGE, duration = SnackbarDuration.Short)
+              }
             },
             modifier = Modifier.padding(horizontal = 28.dp).testTag("AssociationSeeMoreButton")) {
               Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "See more")
@@ -275,7 +319,10 @@ fun AssociationHeader(context: Context) {
           modifier = Modifier.padding(bottom = 14.dp).testTag("AssociationHeaderMembers"))
       Button(
           onClick = {
-            Toast.makeText(context, "<DEBUG> Not implemented yet", Toast.LENGTH_SHORT).show()
+            scope!!.launch {
+              testSnackbar!!.showSnackbar(
+                  message = DEBUG_MESSAGE, duration = SnackbarDuration.Short)
+            }
           },
           modifier = Modifier.testTag("AssociationFollowButton")) {
             Icon(Icons.Filled.Add, contentDescription = "Follow icon")


### PR DESCRIPTION
The line coverage of the "AssociationProfile" can be improved with more tests. This is the purpose of this PR. It includes :

  - Test the different button if they do the the correct behavior
  - To do so, we change the placeholder action "Toast.show" with another one that is easier to test. We use instead "SnackBar".

More test will be done when we will link the backend to this screen