### PR TITLE
chore(action/apk-maker): add a yml file that should make apk of the main automatically

### DIFF
--- a/.github/workflows/apk-maker.yml
+++ b/.github/workflows/apk-maker.yml
@@ -35,6 +35,19 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
+      # Load google-services.json and local.properties from the secrets
+      - name: Decode secrets
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+        run: |
+          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+
+      - name: Grant execute permission for gradlew
+        run: |
+          chmod +x ./gradlew
+
       - name: Assemble app debug APK
         run: bash ./gradlew assembleDebug --stacktrace
 


### PR DESCRIPTION
To be able to download the apk of the app directly from GitHub, a workflow is needed to be setup. This is the purpose of this PR. It includes :

    A apk-maker.yml file that will be useful to setup the Workflow

The "$GOOGLE_SERVICES" and the "$LOCAL_PROPERTIES" were not loaded. This is why the CI crashed when building the apk. This PR is here to fix this problem
