### PR TITLE
fix(explore): restore placeholder image for demo to display associations visually

### DIFF
--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -1,5 +1,6 @@
 package com.android.unio.ui.explore
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -27,12 +28,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.compose.viewModel
-import coil.compose.AsyncImage
+import com.android.unio.R
 import com.android.unio.model.association.Association
 import com.android.unio.model.association.AssociationCategory
 import com.android.unio.model.association.AssociationViewModel
@@ -172,13 +172,17 @@ fun AssociationItem(association: Association, navigationAction: NavigationAction
          * AdEC image is used as the placeholder. Will need to add the actual image later, when the
          * actual view model is used.
          */
-        AsyncImage(
-            model = association.image.toUri(),
-            contentDescription = "Translated description of what the image contains",
-            modifier = Modifier.size(124.dp).testTag("associationImage"),
-            contentScale = ContentScale.Crop // crop the image to fit
-            )
+        Image(
+            painter = painterResource(id = R.drawable.adec),
+            contentDescription = "image description",
+            modifier = Modifier.size(124.dp))
 
+        /**
+         * AsyncImage( model = association.image.toUri(), contentDescription = "Translated
+         * description of what the image contains", modifier =
+         * Modifier.size(124.dp).testTag("associationImage"), contentScale = ContentScale.Crop //
+         * crop the image to fit )
+         */
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(


### PR DESCRIPTION
### Description
This PR restores the placeholder image for the Explore screen to demonstrate the intended behavior of the screen with visible content for the upcoming demo and milestone. While previous efforts were made to implement image URLs for associations, we decided to revert to the placeholder image to better demonstrate the behavior of the screen, instead of having to show, for the milestone 1, empty images slots. The placeholder will be replaced with actual images when all urls work in a future update.