### PR TITLE
Refactor/user data class

### DIFF
--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -59,12 +59,21 @@ fun UnioApp() {
     val user = auth.currentUser
     if (user != null) {
       if (user.isEmailVerified) {
-        navController.navigate(Screen.ACCOUNT_DETAILS)
+        userRepositoryFirestore.getUserWithId(user.uid,{
+          if(it.hasProvidedAccountDetails){
+            navigationActions.navigateTo(Screen.HOME)
+          } else {
+            navigationActions.navigateTo(Screen.ACCOUNT_DETAILS)
+          }
+        },{
+            Log.e("UnioApp", "Error fetching account details: $it")
+            Toast.makeText(context, "Error fetching account details.", Toast.LENGTH_SHORT).show()
+        })
       } else {
-        navController.navigate(Screen.EMAIL_VERIFICATION)
+        navigationActions.navigateTo(Screen.EMAIL_VERIFICATION)
       }
     } else {
-      navController.navigate(Route.AUTH)
+      navigationActions.navigateTo(Route.AUTH)
     }
   }
 

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -59,16 +59,19 @@ fun UnioApp() {
     val user = auth.currentUser
     if (user != null) {
       if (user.isEmailVerified) {
-        userRepositoryFirestore.getUserWithId(user.uid,{
-          if(it.hasProvidedAccountDetails){
-            navigationActions.navigateTo(Screen.HOME)
-          } else {
-            navigationActions.navigateTo(Screen.ACCOUNT_DETAILS)
-          }
-        },{
-            Log.e("UnioApp", "Error fetching account details: $it")
-            Toast.makeText(context, "Error fetching account details.", Toast.LENGTH_SHORT).show()
-        })
+        userRepositoryFirestore.getUserWithId(
+            user.uid,
+            {
+              if (it.hasProvidedAccountDetails) {
+                navigationActions.navigateTo(Screen.HOME)
+              } else {
+                navigationActions.navigateTo(Screen.ACCOUNT_DETAILS)
+              }
+            },
+            {
+              Log.e("UnioApp", "Error fetching account details: $it")
+              Toast.makeText(context, "Error fetching account details.", Toast.LENGTH_SHORT).show()
+            })
       } else {
         navigationActions.navigateTo(Screen.EMAIL_VERIFICATION)
       }

--- a/app/src/main/java/com/android/unio/model/firestore/transform/Hydration.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Hydration.kt
@@ -37,13 +37,17 @@ fun UserRepositoryFirestore.Companion.hydrate(data: Map<String, Any>?): User {
   val followingAssociationsUids = data?.get("followingAssociations") as? List<String> ?: emptyList()
   val followingAssociations = Association.firestoreReferenceListWith(followingAssociationsUids)
 
+  val joinedAssociationsUids = data?.get("joinedAssociations") as? List<String> ?: emptyList()
+  val joinedAssociations = Association.firestoreReferenceListWith(joinedAssociationsUids)
+
   return User(
       uid = data?.get("uid") as? String ?: "",
       email = data?.get("email") as? String ?: "",
       firstName = data?.get("firstName") as? String ?: "",
       lastName = data?.get("lastName") as? String ?: "",
       biography = data?.get("biography") as? String ?: "",
-      followingAssociations = followingAssociations,
+      followedAssociations = followingAssociations,
+      joinedAssociations = joinedAssociations,
       interests =
           (data?.get("interests") as? List<String> ?: emptyList()).map { Interest.valueOf(it) },
       socials =
@@ -51,7 +55,7 @@ fun UserRepositoryFirestore.Companion.hydrate(data: Map<String, Any>?): User {
             UserSocial(Social.valueOf(it["social"] ?: ""), it["content"] ?: "")
           },
       profilePicture = data?.get("profilePicture") as? String ?: "",
-  )
+      hasProvidedAccountDetails = data?.get("hasProvidedAccountDetails") as? Boolean ?: false)
 }
 
 fun EventRepositoryFirestore.Companion.hydrate(data: Map<String, Any>?): Event {

--- a/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
@@ -25,11 +25,12 @@ fun UserRepositoryFirestore.Companion.serialize(user: User): Map<String, Any> {
       "firstName" to user.firstName,
       "lastName" to user.lastName,
       "biography" to user.biography,
-      "followingAssociations" to user.followingAssociations.list.value.map { it.uid },
+      "followingAssociations" to user.followedAssociations.list.value.map { it.uid },
+      "joinedAssociations" to user.joinedAssociations.list.value.map { it.uid },
       "interests" to user.interests.map { it.name },
       "socials" to user.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
       "profilePicture" to user.profilePicture,
-  )
+      "hasProvidedAccountDetails" to user.hasProvidedAccountDetails)
 }
 
 fun EventRepositoryFirestore.Companion.serialize(event: Event): Map<String, Any> {

--- a/app/src/main/java/com/android/unio/model/user/User.kt
+++ b/app/src/main/java/com/android/unio/model/user/User.kt
@@ -36,6 +36,7 @@ data class UserSocial(val social: Social, val content: String)
  * @param lastName The last name of the user.
  * @param biography The biography of the user.
  * @param followedAssociations The associations that the user is following.
+ * @param joinedAssociations The associations that the user is member of.
  * @param interests The interests of the user.
  * @param socials The socials of the user.
  * @param profilePicture The URL to the profile picture in Firebase storage.

--- a/app/src/main/java/com/android/unio/model/user/User.kt
+++ b/app/src/main/java/com/android/unio/model/user/User.kt
@@ -35,10 +35,11 @@ data class UserSocial(val social: Social, val content: String)
  * @param firstName The first name of the user.
  * @param lastName The last name of the user.
  * @param biography The biography of the user.
- * @param followingAssociations The associations that the user is following.
+ * @param followedAssociations The associations that the user is following.
  * @param interests The interests of the user.
  * @param socials The socials of the user.
  * @param profilePicture The URL to the profile picture in Firebase storage.
+ * @param hasProvidedAccountDetails Whether the user has provided account details.
  */
 data class User(
     val uid: String,
@@ -46,10 +47,12 @@ data class User(
     val firstName: String,
     val lastName: String,
     val biography: String,
-    val followingAssociations: ReferenceList<Association>,
+    val followedAssociations: ReferenceList<Association>,
+    val joinedAssociations: ReferenceList<Association>,
     val interests: List<Interest>,
     val socials: List<UserSocial>,
-    val profilePicture: String
+    val profilePicture: String,
+    val hasProvidedAccountDetails: Boolean
 ) {
   companion object
 }

--- a/app/src/main/java/com/android/unio/ui/authentication/AccountDetails.kt
+++ b/app/src/main/java/com/android/unio/ui/authentication/AccountDetails.kt
@@ -178,10 +178,12 @@ fun AccountDetails(
                       firstName = firstName,
                       lastName = lastName,
                       biography = bio,
-                      followingAssociations = Association.emptyFirestoreReferenceList(),
+                      followedAssociations = Association.emptyFirestoreReferenceList(),
+                      joinedAssociations = Association.emptyFirestoreReferenceList(),
                       interests = interests.filter { it.second.value }.map { it.first },
                       socials = emptyList(),
-                      profilePicture = "")
+                      profilePicture = "",
+                      hasProvidedAccountDetails = true)
               uploadUser(user, userRepositoryFirestore, navigationAction, context)
               navigationAction.navigateTo(Screen.HOME)
             }) {

--- a/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
+++ b/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
@@ -46,13 +46,15 @@ class HydrationAndSerializationTest {
             firstName = "userFirst",
             lastName = "userLast",
             biography = "An example user",
-            followingAssociations = Association.firestoreReferenceListWith(listOf("1", "2")),
+            followedAssociations = Association.firestoreReferenceListWith(listOf("1", "2")),
+            joinedAssociations = Association.firestoreReferenceListWith(listOf("1", "2")),
             interests = listOf(Interest.SPORTS, Interest.MUSIC),
             socials =
                 listOf(
                     UserSocial(Social.INSTAGRAM, "Insta"),
                     UserSocial(Social.WEBSITE, "example.com")),
-            profilePicture = "https://www.example.com/image")
+            profilePicture = "https://www.example.com/image",
+            hasProvidedAccountDetails = true)
 
     association =
         Association(
@@ -89,12 +91,14 @@ class HydrationAndSerializationTest {
     assertEquals(user.firstName, serialized["firstName"])
     assertEquals(user.lastName, serialized["lastName"])
     assertEquals(user.biography, serialized["biography"])
-    assertEquals(user.followingAssociations.list.value, serialized["followingAssociations"])
+    assertEquals(user.followedAssociations.list.value, serialized["followingAssociations"])
+    assertEquals(user.joinedAssociations.list.value, serialized["joinedAssociations"])
     assertEquals(user.interests.map { it.name }, serialized["interests"])
     assertEquals(
         user.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
         serialized["socials"])
     assertEquals(user.profilePicture, serialized["profilePicture"])
+    assertEquals(user.hasProvidedAccountDetails, serialized["hasProvidedAccountDetails"])
 
     val hydrated = UserRepositoryFirestore.hydrate(serialized)
 
@@ -103,10 +107,12 @@ class HydrationAndSerializationTest {
     assertEquals(user.firstName, hydrated.firstName)
     assertEquals(user.lastName, hydrated.lastName)
     assertEquals(user.biography, hydrated.biography)
-    assertEquals(user.followingAssociations.list.value, hydrated.followingAssociations.list.value)
+    assertEquals(user.followedAssociations.list.value, hydrated.followedAssociations.list.value)
+    assertEquals(user.joinedAssociations.list.value, hydrated.joinedAssociations.list.value)
     assertEquals(user.interests, hydrated.interests)
     assertEquals(user.socials, hydrated.socials)
     assertEquals(user.profilePicture, hydrated.profilePicture)
+    assertEquals(user.hasProvidedAccountDetails, hydrated.hasProvidedAccountDetails)
   }
 
   @Test
@@ -174,10 +180,12 @@ class HydrationAndSerializationTest {
     assertEquals("", hydrated.firstName)
     assertEquals("", hydrated.lastName)
     assertEquals("", hydrated.biography)
-    assertEquals(emptyList<String>(), hydrated.followingAssociations.list.value)
+    assertEquals(emptyList<String>(), hydrated.followedAssociations.list.value)
+    assertEquals(emptyList<String>(), hydrated.joinedAssociations.list.value)
     assertEquals(emptyList<Interest>(), hydrated.interests)
     assertEquals(emptyList<UserSocial>(), hydrated.socials)
     assertEquals("", hydrated.profilePicture)
+    assertEquals(false, hydrated.hasProvidedAccountDetails)
   }
 
   @Test

--- a/app/src/test/java/com/android/unio/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/unio/model/user/UserRepositoryFirestoreTest.kt
@@ -63,13 +63,15 @@ class UserRepositoryFirestoreTest {
             firstName = "Example 1",
             lastName = "Last name 1",
             biography = "An example user",
-            followingAssociations = Association.emptyFirestoreReferenceList(),
+            followedAssociations = Association.emptyFirestoreReferenceList(),
+            joinedAssociations = Association.emptyFirestoreReferenceList(),
             interests = listOf(Interest.SPORTS, Interest.MUSIC),
             socials =
                 listOf(
                     UserSocial(Social.INSTAGRAM, "Insta"),
                     UserSocial(Social.WEBSITE, "example.com")),
-            profilePicture = "https://www.example.com/image")
+            profilePicture = "https://www.example.com/image",
+            hasProvidedAccountDetails = true)
 
     user2 =
         User(
@@ -78,13 +80,15 @@ class UserRepositoryFirestoreTest {
             firstName = "Example 2",
             lastName = "Last name 2",
             biography = "An example user 2",
-            followingAssociations = Association.emptyFirestoreReferenceList(),
+            followedAssociations = Association.emptyFirestoreReferenceList(),
+            joinedAssociations = Association.emptyFirestoreReferenceList(),
             interests = listOf(Interest.FESTIVALS, Interest.GAMING),
             socials =
                 listOf(
                     UserSocial(Social.SNAPCHAT, "Snap"),
                     UserSocial(Social.WEBSITE, "example2.com")),
-            profilePicture = "https://www.example.com/image2")
+            profilePicture = "https://www.example.com/image2",
+            hasProvidedAccountDetails = true)
 
     `when`(userCollectionReference.get()).thenReturn(querySnapshotTask)
     `when`(userCollectionReference.document(eq(user1.uid))).thenReturn(documentReference)
@@ -118,12 +122,15 @@ class UserRepositoryFirestoreTest {
     `when`(map1.get("lastName")).thenReturn(user1.lastName)
     `when`(map1.get("biography")).thenReturn(user1.biography)
     `when`(map1.get("followingAssociations"))
-        .thenReturn(user1.followingAssociations.list.value.map { it.uid })
+        .thenReturn(user1.followedAssociations.list.value.map { it.uid })
+    `when`(map1.get("joinedAssociations"))
+        .thenReturn(user1.joinedAssociations.list.value.map { it.uid })
     `when`(map1.get("interests")).thenReturn(user1.interests.map { it.name })
     `when`(map1.get("socials"))
         .thenReturn(
             user1.socials.map { mapOf("social" to it.social.name, "content" to it.content) })
     `when`(map1.get("profilePicture")).thenReturn(user1.profilePicture)
+    `when`(map1.get("hasProvidedAccountDetails")).thenReturn(user1.hasProvidedAccountDetails)
 
     // Only set the uid field for user2
     `when`(map2.get("uid")).thenReturn(user2.uid)
@@ -138,12 +145,15 @@ class UserRepositoryFirestoreTest {
     `when`(map2.get("lastName")).thenReturn(user2.lastName)
     `when`(map2.get("biography")).thenReturn(user2.biography)
     `when`(map2.get("followingAssociations"))
-        .thenReturn(user2.followingAssociations.list.value.map { it.uid })
+        .thenReturn(user2.followedAssociations.list.value.map { it.uid })
+    `when`(map2.get("joinedAssociations"))
+        .thenReturn(user2.joinedAssociations.list.value.map { it.uid })
     `when`(map2.get("interests")).thenReturn(user2.interests.map { it.name })
     `when`(map2.get("socials"))
         .thenReturn(
             user2.socials.map { mapOf("social" to it.social.name, "content" to it.content) })
     `when`(map2.get("profilePicture")).thenReturn(user2.profilePicture)
+    `when`(map2.get("hasProvidedAccountDetails")).thenReturn(user2.hasProvidedAccountDetails)
 
     repository.getUsers(
         onSuccess = { users ->
@@ -155,13 +165,17 @@ class UserRepositoryFirestoreTest {
           assertEquals(user1.lastName, users[0].lastName)
           assertEquals(user1.biography, users[0].biography)
           assertEquals(
-              user1.followingAssociations.list.value.map { it.uid },
-              users[0].followingAssociations.list.value.map { it.uid })
+              user1.followedAssociations.list.value.map { it.uid },
+              users[0].followedAssociations.list.value.map { it.uid })
+          assertEquals(
+              user1.joinedAssociations.list.value.map { it.uid },
+              users[0].joinedAssociations.list.value.map { it.uid })
           assertEquals(user1.interests.map { it.name }, users[0].interests.map { it.name })
           assertEquals(
               user1.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               users[0].socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(user1.profilePicture, users[0].profilePicture)
+          assertEquals(user1.hasProvidedAccountDetails, users[0].hasProvidedAccountDetails)
 
           assertEquals(user2.uid, users[1].uid)
           assertEquals(user2.email, users[1].email)
@@ -169,13 +183,17 @@ class UserRepositoryFirestoreTest {
           assertEquals(user2.lastName, users[1].lastName)
           assertEquals(user2.biography, users[1].biography)
           assertEquals(
-              user2.followingAssociations.list.value.map { it.uid },
-              users[1].followingAssociations.list.value.map { it.uid })
+              user2.followedAssociations.list.value.map { it.uid },
+              users[1].followedAssociations.list.value.map { it.uid })
+          assertEquals(
+              user2.joinedAssociations.list.value.map { it.uid },
+              users[1].joinedAssociations.list.value.map { it.uid })
           assertEquals(user2.interests.map { it.name }, users[1].interests.map { it.name })
           assertEquals(
               user2.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               users[1].socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(user2.profilePicture, users[1].profilePicture)
+          assertEquals(user2.hasProvidedAccountDetails, users[1].hasProvidedAccountDetails)
         },
         onFailure = { exception -> assert(false) })
   }
@@ -193,10 +211,12 @@ class UserRepositoryFirestoreTest {
                   firstName = "",
                   lastName = "",
                   biography = "",
-                  followingAssociations = Association.emptyFirestoreReferenceList(),
+                  followedAssociations = Association.emptyFirestoreReferenceList(),
+                  joinedAssociations = Association.emptyFirestoreReferenceList(),
                   interests = emptyList(),
                   socials = emptyList(),
-                  profilePicture = "")
+                  profilePicture = "",
+                  hasProvidedAccountDetails = false)
           assertEquals(2, users.size)
 
           assertEquals(user1.uid, users[0].uid)
@@ -205,13 +225,17 @@ class UserRepositoryFirestoreTest {
           assertEquals(user1.lastName, users[0].lastName)
           assertEquals(user1.biography, users[0].biography)
           assertEquals(
-              user1.followingAssociations.list.value.map { it.uid },
-              users[0].followingAssociations.list.value.map { it.uid })
+              user1.followedAssociations.list.value.map { it.uid },
+              users[0].followedAssociations.list.value.map { it.uid })
+          assertEquals(
+              user1.joinedAssociations.list.value.map { it.uid },
+              users[0].joinedAssociations.list.value.map { it.uid })
           assertEquals(user1.interests.map { it.name }, users[0].interests.map { it.name })
           assertEquals(
               user1.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               users[0].socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(user1.profilePicture, users[0].profilePicture)
+          assertEquals(user1.hasProvidedAccountDetails, users[0].hasProvidedAccountDetails)
 
           assertEquals(emptyUser.uid, users[1].uid)
           assertEquals("", users[1].email)
@@ -219,13 +243,17 @@ class UserRepositoryFirestoreTest {
           assertEquals("", users[1].lastName)
           assertEquals("", users[1].biography)
           assertEquals(
-              emptyUser.followingAssociations.list.value.map { it.uid },
-              users[1].followingAssociations.list.value.map { it.uid })
+              emptyUser.followedAssociations.list.value.map { it.uid },
+              users[1].followedAssociations.list.value.map { it.uid })
+          assertEquals(
+              emptyUser.joinedAssociations.list.value.map { it.uid },
+              users[1].joinedAssociations.list.value.map { it.uid })
           assertEquals(emptyUser.interests.map { it.name }, users[1].interests.map { it.name })
           assertEquals(
               emptyUser.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               users[1].socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(emptyUser.profilePicture, users[1].profilePicture)
+          assertEquals(emptyUser.hasProvidedAccountDetails, users[1].hasProvidedAccountDetails)
         },
         onFailure = { exception -> assert(false) })
   }
@@ -241,13 +269,17 @@ class UserRepositoryFirestoreTest {
           assertEquals(user1.lastName, user.lastName)
           assertEquals(user1.biography, user.biography)
           assertEquals(
-              user1.followingAssociations.list.value.map { it.uid },
-              user.followingAssociations.list.value.map { it.uid })
+              user1.followedAssociations.list.value.map { it.uid },
+              user.followedAssociations.list.value.map { it.uid })
+          assertEquals(
+              user1.joinedAssociations.list.value.map { it.uid },
+              user.joinedAssociations.list.value.map { it.uid })
           assertEquals(user1.interests.map { it.name }, user.interests.map { it.name })
           assertEquals(
               user1.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               user.socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(user1.profilePicture, user.profilePicture)
+          assertEquals(user1.hasProvidedAccountDetails, user.hasProvidedAccountDetails)
         },
         onFailure = { exception -> assert(false) })
   }

--- a/app/src/test/java/com/android/unio/model/user/UserTest.kt
+++ b/app/src/test/java/com/android/unio/model/user/UserTest.kt
@@ -40,10 +40,12 @@ class UserTest {
             "Doe",
             "An example user",
             Association.emptyFirestoreReferenceList(),
+            Association.emptyFirestoreReferenceList(),
             listOf(Interest.SPORTS, Interest.MUSIC),
             listOf(
                 UserSocial(Social.INSTAGRAM, "Insta"), UserSocial(Social.WEBSITE, "example.com")),
-            "https://www.example.com/image")
+            "https://www.example.com/image",
+            true)
     assertEquals("1", user.uid)
     assertEquals("john@example.com", user.email)
     assertEquals("John", user.firstName)


### PR DESCRIPTION
This PR includes the refactored user data class, new navigation logic and all the refactoring needed for the tests. 
For the user data class I added 2 new fields, those being : `joinedAssociations` and `hasProvidedAccountDetails`, for the following reasons: 
- It is now possible to see what associations a user is part of.
- The latter is to ensure correct navigation logic. If in the user has not completed giving his account details but has verified his email, he will be redirected to the `AccountDetails` Screen instead of straight to `Home`.

Potential Risks:
- The `joinedAssociations` Reference List might be desynced with the `members` Reference List found in the association data class. (We partly loose the [SSOT](https://en.wikipedia.org/wiki/Single_source_of_truth) concept).

