### PR TITLE
Refactor User data class - Remove pointless attribute 

### DIFF
--- a/app/src/androidTest/java/com/android/unio/ui/user/UserProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/user/UserProfileTest.kt
@@ -54,8 +54,7 @@ class UserProfileTest {
               listOf(
                   UserSocial(Social.INSTAGRAM, "Instagram"),
                   UserSocial(Social.WEBSITE, "example.com")),
-          profilePicture = "https://www.example.com/image",
-          hasProvidedAccountDetails = true)
+          profilePicture = "https://www.example.com/image")
 
   @Before
   fun setUp() {

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -66,7 +66,7 @@ fun UnioApp() {
         userRepositoryFirestore.getUserWithId(
             user.uid,
             {
-              if (it.hasProvidedAccountDetails) {
+              if (it.firstName.isNotEmpty()) {
                 navigationActions.navigateTo(Screen.HOME)
               } else {
                 navigationActions.navigateTo(Screen.ACCOUNT_DETAILS)

--- a/app/src/main/java/com/android/unio/model/firestore/transform/Hydration.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Hydration.kt
@@ -54,8 +54,7 @@ fun UserRepositoryFirestore.Companion.hydrate(data: Map<String, Any>?): User {
           (data?.get("socials") as? List<Map<String, String>> ?: emptyList()).map {
             UserSocial(Social.valueOf(it["social"] ?: ""), it["content"] ?: "")
           },
-      profilePicture = data?.get("profilePicture") as? String ?: "",
-      hasProvidedAccountDetails = data?.get("hasProvidedAccountDetails") as? Boolean ?: false)
+      profilePicture = data?.get("profilePicture") as? String ?: "")
 }
 
 fun EventRepositoryFirestore.Companion.hydrate(data: Map<String, Any>?): Event {

--- a/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
@@ -29,8 +29,7 @@ fun UserRepositoryFirestore.Companion.serialize(user: User): Map<String, Any> {
       "joinedAssociations" to user.joinedAssociations.list.value.map { it.uid },
       "interests" to user.interests.map { it.name },
       "socials" to user.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
-      "profilePicture" to user.profilePicture,
-      "hasProvidedAccountDetails" to user.hasProvidedAccountDetails)
+      "profilePicture" to user.profilePicture)
 }
 
 fun EventRepositoryFirestore.Companion.serialize(event: Event): Map<String, Any> {

--- a/app/src/main/java/com/android/unio/model/user/User.kt
+++ b/app/src/main/java/com/android/unio/model/user/User.kt
@@ -57,8 +57,7 @@ data class User(
     val joinedAssociations: ReferenceList<Association>,
     val interests: List<Interest>,
     val socials: List<UserSocial>,
-    val profilePicture: String,
-    val hasProvidedAccountDetails: Boolean
+    val profilePicture: String
 ) {
   companion object
 }

--- a/app/src/main/java/com/android/unio/ui/authentication/AccountDetails.kt
+++ b/app/src/main/java/com/android/unio/ui/authentication/AccountDetails.kt
@@ -223,8 +223,7 @@ fun AccountDetails(
                       joinedAssociations = Association.emptyFirestoreReferenceList(),
                       interests = interests.filter { it.second.value }.map { it.first },
                       socials = socials,
-                      profilePicture = "",
-                      hasProvidedAccountDetails = true)
+                      profilePicture = "")
               isErrors = checkNewUser(user)
               if (isErrors.isEmpty()) {
                 userViewModel.addUser(

--- a/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
+++ b/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
@@ -53,8 +53,7 @@ class HydrationAndSerializationTest {
                 listOf(
                     UserSocial(Social.INSTAGRAM, "Insta"),
                     UserSocial(Social.WEBSITE, "example.com")),
-            profilePicture = "https://www.example.com/image",
-            hasProvidedAccountDetails = true)
+            profilePicture = "https://www.example.com/image")
 
     association =
         Association(
@@ -98,7 +97,6 @@ class HydrationAndSerializationTest {
         user.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
         serialized["socials"])
     assertEquals(user.profilePicture, serialized["profilePicture"])
-    assertEquals(user.hasProvidedAccountDetails, serialized["hasProvidedAccountDetails"])
 
     val hydrated = UserRepositoryFirestore.hydrate(serialized)
 
@@ -112,7 +110,6 @@ class HydrationAndSerializationTest {
     assertEquals(user.interests, hydrated.interests)
     assertEquals(user.socials, hydrated.socials)
     assertEquals(user.profilePicture, hydrated.profilePicture)
-    assertEquals(user.hasProvidedAccountDetails, hydrated.hasProvidedAccountDetails)
   }
 
   @Test
@@ -185,7 +182,6 @@ class HydrationAndSerializationTest {
     assertEquals(emptyList<Interest>(), hydrated.interests)
     assertEquals(emptyList<UserSocial>(), hydrated.socials)
     assertEquals("", hydrated.profilePicture)
-    assertEquals(false, hydrated.hasProvidedAccountDetails)
   }
 
   @Test

--- a/app/src/test/java/com/android/unio/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/unio/model/user/UserRepositoryFirestoreTest.kt
@@ -70,8 +70,7 @@ class UserRepositoryFirestoreTest {
                 listOf(
                     UserSocial(Social.INSTAGRAM, "Insta"),
                     UserSocial(Social.WEBSITE, "example.com")),
-            profilePicture = "https://www.example.com/image",
-            hasProvidedAccountDetails = true)
+            profilePicture = "https://www.example.com/image")
 
     user2 =
         User(
@@ -87,8 +86,7 @@ class UserRepositoryFirestoreTest {
                 listOf(
                     UserSocial(Social.SNAPCHAT, "Snap"),
                     UserSocial(Social.WEBSITE, "example2.com")),
-            profilePicture = "https://www.example.com/image2",
-            hasProvidedAccountDetails = true)
+            profilePicture = "https://www.example.com/image2")
 
     `when`(userCollectionReference.get()).thenReturn(querySnapshotTask)
     `when`(userCollectionReference.document(eq(user1.uid))).thenReturn(documentReference)
@@ -130,7 +128,6 @@ class UserRepositoryFirestoreTest {
         .thenReturn(
             user1.socials.map { mapOf("social" to it.social.name, "content" to it.content) })
     `when`(map1.get("profilePicture")).thenReturn(user1.profilePicture)
-    `when`(map1.get("hasProvidedAccountDetails")).thenReturn(user1.hasProvidedAccountDetails)
 
     // Only set the uid field for user2
     `when`(map2.get("uid")).thenReturn(user2.uid)
@@ -153,7 +150,6 @@ class UserRepositoryFirestoreTest {
         .thenReturn(
             user2.socials.map { mapOf("social" to it.social.name, "content" to it.content) })
     `when`(map2.get("profilePicture")).thenReturn(user2.profilePicture)
-    `when`(map2.get("hasProvidedAccountDetails")).thenReturn(user2.hasProvidedAccountDetails)
 
     repository.getUsers(
         onSuccess = { users ->
@@ -175,7 +171,6 @@ class UserRepositoryFirestoreTest {
               user1.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               users[0].socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(user1.profilePicture, users[0].profilePicture)
-          assertEquals(user1.hasProvidedAccountDetails, users[0].hasProvidedAccountDetails)
 
           assertEquals(user2.uid, users[1].uid)
           assertEquals(user2.email, users[1].email)
@@ -193,7 +188,6 @@ class UserRepositoryFirestoreTest {
               user2.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               users[1].socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(user2.profilePicture, users[1].profilePicture)
-          assertEquals(user2.hasProvidedAccountDetails, users[1].hasProvidedAccountDetails)
         },
         onFailure = { exception -> assert(false) })
   }
@@ -215,8 +209,7 @@ class UserRepositoryFirestoreTest {
                   joinedAssociations = Association.emptyFirestoreReferenceList(),
                   interests = emptyList(),
                   socials = emptyList(),
-                  profilePicture = "",
-                  hasProvidedAccountDetails = false)
+                  profilePicture = "")
           assertEquals(2, users.size)
 
           assertEquals(user1.uid, users[0].uid)
@@ -235,7 +228,6 @@ class UserRepositoryFirestoreTest {
               user1.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               users[0].socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(user1.profilePicture, users[0].profilePicture)
-          assertEquals(user1.hasProvidedAccountDetails, users[0].hasProvidedAccountDetails)
 
           assertEquals(emptyUser.uid, users[1].uid)
           assertEquals("", users[1].email)
@@ -253,7 +245,6 @@ class UserRepositoryFirestoreTest {
               emptyUser.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               users[1].socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(emptyUser.profilePicture, users[1].profilePicture)
-          assertEquals(emptyUser.hasProvidedAccountDetails, users[1].hasProvidedAccountDetails)
         },
         onFailure = { exception -> assert(false) })
   }
@@ -279,7 +270,6 @@ class UserRepositoryFirestoreTest {
               user1.socials.map { mapOf("social" to it.social.name, "content" to it.content) },
               user.socials.map { mapOf("social" to it.social.name, "content" to it.content) })
           assertEquals(user1.profilePicture, user.profilePicture)
-          assertEquals(user1.hasProvidedAccountDetails, user.hasProvidedAccountDetails)
         },
         onFailure = { exception -> assert(false) })
   }

--- a/app/src/test/java/com/android/unio/model/user/UserTest.kt
+++ b/app/src/test/java/com/android/unio/model/user/UserTest.kt
@@ -44,8 +44,7 @@ class UserTest {
             listOf(Interest.SPORTS, Interest.MUSIC),
             listOf(
                 UserSocial(Social.INSTAGRAM, "Insta"), UserSocial(Social.WEBSITE, "example.com")),
-            "https://www.example.com/image",
-            true)
+            "https://www.example.com/image")
     assertEquals("1", user.uid)
     assertEquals("john@example.com", user.email)
     assertEquals("John", user.firstName)
@@ -71,8 +70,7 @@ class UserTest {
             Association.emptyFirestoreReferenceList(),
             listOf(Interest.SPORTS),
             listOf(UserSocial(Social.INSTAGRAM, "username")),
-            "https://example.com/image",
-            false)
+            "https://example.com/image")
 
     val userEmptyLastName =
         User(
@@ -85,8 +83,7 @@ class UserTest {
             Association.emptyFirestoreReferenceList(),
             listOf(Interest.SPORTS),
             listOf(UserSocial(Social.INSTAGRAM, "username")),
-            "https://example.com/image",
-            false)
+            "https://example.com/image")
 
     val userEmptyNameAndLastName =
         User(
@@ -99,8 +96,7 @@ class UserTest {
             Association.emptyFirestoreReferenceList(),
             listOf(Interest.SPORTS),
             listOf(UserSocial(Social.INSTAGRAM, "username")),
-            "https://example.com/image",
-            false)
+            "https://example.com/image")
     val expectedErrors1 = mutableSetOf(AccountDetailsError.EMPTY_FIRST_NAME)
     val expectedErrors2 = mutableSetOf(AccountDetailsError.EMPTY_LAST_NAME)
     val expectedErrors3 =

--- a/app/src/test/java/com/android/unio/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/unio/model/user/UserViewModelTest.kt
@@ -24,8 +24,7 @@ class UserViewModelTest {
               listOf(
                   UserSocial(Social.INSTAGRAM, "Instagram"),
                   UserSocial(Social.WEBSITE, "example.com")),
-          profilePicture = "https://www.example.com/image",
-          hasProvidedAccountDetails = true)
+          profilePicture = "https://www.example.com/image")
 
   @MockK private lateinit var repository: UserRepository
   private lateinit var userViewModel: UserViewModel


### PR DESCRIPTION
Small PR that refactors the user data class as we've noticed the the `hasProvidedAccountDetails` boolean attribute is completely redundant. We can instead use any other required field such as `FirstName` or `LastName` to check that the user has indeed filled out his `AccountDetails`. This ensures that the navigation still works properly.

This PR includes : 
- Changed User data class.
- All the subsequent modifications for tests and other methods.