### PR TITLE
Chore: refactor tests and cleanup view models

### DIFF
--- a/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
@@ -2,18 +2,12 @@ package com.android.unio.model.association
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepository
-import com.android.unio.model.event.EventRepositoryFirestore
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
-import com.google.firebase.Firebase
-import com.google.firebase.firestore.firestore
 import java.io.InputStream
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 class AssociationViewModel(
     private val associationRepository: AssociationRepository,
@@ -32,31 +26,16 @@ class AssociationViewModel(
     associationRepository.init { getAssociations() }
   }
 
-  companion object {
-    val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-          @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return AssociationViewModel(
-                AssociationRepositoryFirestore(Firebase.firestore),
-                EventRepositoryFirestore(Firebase.firestore))
-                as T
-          }
-        }
-  }
-
   fun getEventsForAssociation(association: Association, onSuccess: (List<Event>) -> Unit) {
-    viewModelScope.launch {
-      eventRepository.getEventsOfAssociation(
-          association.uid,
-          onSuccess = onSuccess,
-          onFailure = { exception ->
-            Log.e(
-                "ExploreViewModel",
-                "Failed to get events for association ${association.fullName}",
-                exception)
-          })
-    }
+    eventRepository.getEventsOfAssociation(
+        association.uid,
+        onSuccess = onSuccess,
+        onFailure = { exception ->
+          Log.e(
+              "ExploreViewModel",
+              "Failed to get events for association ${association.fullName}",
+              exception)
+        })
   }
 
   /**
@@ -65,17 +44,15 @@ class AssociationViewModel(
    * set to an empty list.
    */
   fun getAssociations() {
-    viewModelScope.launch {
-      associationRepository.getAssociations(
-          onSuccess = { fetchedAssociations ->
-            _associations.value = fetchedAssociations
-            _associationsByCategory.value = fetchedAssociations.groupBy { it.category }
-          },
-          onFailure = { exception ->
-            _associations.value = emptyList()
-            Log.e("ExploreViewModel", "Failed to fetch associations", exception)
-          })
-    }
+    associationRepository.getAssociations(
+        onSuccess = { fetchedAssociations ->
+          _associations.value = fetchedAssociations
+          _associationsByCategory.value = fetchedAssociations.groupBy { it.category }
+        },
+        onFailure = { exception ->
+          _associations.value = emptyList()
+          Log.e("ExploreViewModel", "Failed to fetch associations", exception)
+        })
   }
 
   fun addAssociation(
@@ -84,16 +61,14 @@ class AssociationViewModel(
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    viewModelScope.launch {
-      imageRepository.uploadImage(
-          inputStream,
-          "images/associations/${association.uid}",
-          { uri ->
-            association.image = uri
-            associationRepository.addAssociation(association, onSuccess, onFailure)
-          },
-          { e -> Log.e("ImageRepository", "Failed to store image : $e") })
-    }
+    imageRepository.uploadImage(
+        inputStream,
+        "images/associations/${association.uid}",
+        { uri ->
+          association.image = uri
+          associationRepository.addAssociation(association, onSuccess, onFailure)
+        },
+        { e -> Log.e("ImageRepository", "Failed to store image : $e") })
   }
 
   /**

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -50,7 +50,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.android.unio.R
 import com.android.unio.model.association.Association
@@ -75,7 +74,7 @@ private var scope: CoroutineScope? = null
 fun AssociationProfileScreen(
     navigationAction: NavigationAction,
     associationId: String,
-    associationViewModel: AssociationViewModel = viewModel(factory = AssociationViewModel.Factory),
+    associationViewModel: AssociationViewModel,
     userViewModel: UserViewModel
 ) {
   val context = LocalContext.current

--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.unio.R
 import com.android.unio.model.association.Association
 import com.android.unio.model.association.AssociationCategory
@@ -55,7 +54,7 @@ import com.android.unio.ui.theme.AppTypography
 @Composable
 fun ExploreScreen(
     navigationAction: NavigationAction,
-    associationViewModel: AssociationViewModel = viewModel(factory = AssociationViewModel.Factory),
+    associationViewModel: AssociationViewModel,
     searchViewModel: SearchViewModel
 ) {
 


### PR DESCRIPTION
## Description:

This PR addresses code quality improvements and refactoring in response to feedback received from the first sprints. The updates contribute to a more consistent code.

## Motivation and context:

During the first two sprints, certain coding issues were noted by the coaches. This PR aims to address the following remarks:

- Commented-out tests in the code. If these tests aren’t passing due to specific issues, consider adding a note to explain why they’re currently disabled. If they’re not useful, however, it’s best to remove them entirely to keep the codebase clear and reduce clutter.
- A few instances of hardcoded text were found; it would be best to extract these and place them in the string resources file for maintainability.
- In AssociationViewModel, asynchronous launch with a coroutine was used, but the code is structured around callbacks rather than coroutines. Sticking with one approach is recommended; in this case, removing the coroutine launch would be more efficient.
- In the view models, when using a MutableStateFlow to back a StateFlow, remember to call asStateFlow() on the MutableStateFlow. This will create a readOnlyStateFlow, making it clear that the value is immutable and preventing modifications from outside the viewModel.
- There’s an opportunity to improve test coverage, particularly around UI and viewModel code, which are generally straightforward to test and would enhance reliability.

### Code Cleanup:

- Removed unnecessary commented-out code. **(TBD)**
- Relocated hardcoded text to strings.xml. **(TBD / To check if not already done)**

### AssociationViewModel:

- Removed Factory companion object
- Removed coroutines

### StateFlow Refactoring:

- Applied asStateFlow() on MutableStateFlow properties in the view models to enforce immutability **(TBD)**

### Test Coverage:

- Expanded test cases for UI components and view models to enhance code reliability **(TBD / To check if not already done)**
