### PR TITLE
Connect event frontend to the search backend

### DIFF
--- a/app/src/androidTest/java/com/android/unio/screen/EventListOverviewTest.kt
+++ b/app/src/androidTest/java/com/android/unio/screen/EventListOverviewTest.kt
@@ -26,8 +26,8 @@ import org.mockito.Mockito.mock
 import org.mockito.kotlin.verify
 
 /**
- * Test class for the HomeScreen Composable. This class contains unit tests to validate the
- * behavior of the Event List UI.
+ * Test class for the HomeScreen Composable. This class contains unit tests to validate the behavior
+ * of the Event List UI.
  */
 @ExperimentalUnitApi
 class EventListOverviewTest {
@@ -66,7 +66,8 @@ class EventListOverviewTest {
             }
           }
       val eventViewModel = EventViewModel(emptyEventRepository)
-      HomeScreen(navigationAction, eventViewModel = eventViewModel, searchViewModel = searchViewModel)
+      HomeScreen(
+          navigationAction, eventViewModel = eventViewModel, searchViewModel = searchViewModel)
     }
 
     composeTestRule.onNodeWithTag("event_emptyEventPrompt").assertExists()
@@ -81,7 +82,10 @@ class EventListOverviewTest {
   fun testMapButton() {
     composeTestRule.setContent {
       val eventViewModel = EventViewModel(mockEventRepository)
-      HomeScreen(navigationAction = navigationAction, eventViewModel = eventViewModel, searchViewModel = searchViewModel)
+      HomeScreen(
+          navigationAction = navigationAction,
+          eventViewModel = eventViewModel,
+          searchViewModel = searchViewModel)
     }
     composeTestRule.onNodeWithTag("event_MapButton").assertExists()
     composeTestRule.onNodeWithTag("event_MapButton").assertHasClickAction()
@@ -99,7 +103,8 @@ class EventListOverviewTest {
   fun testClickFollowingAndAdd() = runBlockingTest {
     composeTestRule.setContent {
       val eventViewModel = EventViewModel(mockEventRepository)
-      HomeScreen(navigationAction, eventViewModel = eventViewModel, searchViewModel = searchViewModel)
+      HomeScreen(
+          navigationAction, eventViewModel = eventViewModel, searchViewModel = searchViewModel)
     }
 
     // Ensure the 'Following' tab exists and perform a click.

--- a/app/src/androidTest/java/com/android/unio/screen/EventListOverviewTest.kt
+++ b/app/src/androidTest/java/com/android/unio/screen/EventListOverviewTest.kt
@@ -9,9 +9,14 @@ import androidx.compose.ui.unit.ExperimentalUnitApi
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepositoryMock
 import com.android.unio.model.event.EventViewModel
+import com.android.unio.model.search.SearchRepository
+import com.android.unio.model.search.SearchViewModel
 import com.android.unio.ui.home.HomeScreen
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.navigation.Screen
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import io.mockk.spyk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
@@ -20,10 +25,8 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.verify
 
-// import org.robolectric.RobolectricTestRunner
-
 /**
- * Test class for the EventListOverview Composable. This class contains unit tests to validate the
+ * Test class for the HomeScreen Composable. This class contains unit tests to validate the
  * behavior of the Event List UI.
  */
 @ExperimentalUnitApi
@@ -35,8 +38,14 @@ class EventListOverviewTest {
   private val mockEventRepository = EventRepositoryMock()
   private lateinit var navigationAction: NavigationAction
 
+  private lateinit var searchViewModel: SearchViewModel
+  @MockK(relaxed = true) private lateinit var searchRepository: SearchRepository
+
   @Before
   fun setUp() {
+    MockKAnnotations.init(this)
+    searchViewModel = spyk(SearchViewModel(searchRepository))
+
     navigationAction = mock(NavigationAction::class.java)
   }
 
@@ -57,7 +66,7 @@ class EventListOverviewTest {
             }
           }
       val eventViewModel = EventViewModel(emptyEventRepository)
-      HomeScreen(navigationAction, eventViewModel = eventViewModel)
+      HomeScreen(navigationAction, eventViewModel = eventViewModel, searchViewModel = searchViewModel)
     }
 
     composeTestRule.onNodeWithTag("event_emptyEventPrompt").assertExists()
@@ -72,7 +81,7 @@ class EventListOverviewTest {
   fun testMapButton() {
     composeTestRule.setContent {
       val eventViewModel = EventViewModel(mockEventRepository)
-      HomeScreen(navigationAction = navigationAction, eventViewModel = eventViewModel)
+      HomeScreen(navigationAction = navigationAction, eventViewModel = eventViewModel, searchViewModel = searchViewModel)
     }
     composeTestRule.onNodeWithTag("event_MapButton").assertExists()
     composeTestRule.onNodeWithTag("event_MapButton").assertHasClickAction()
@@ -90,7 +99,7 @@ class EventListOverviewTest {
   fun testClickFollowingAndAdd() = runBlockingTest {
     composeTestRule.setContent {
       val eventViewModel = EventViewModel(mockEventRepository)
-      HomeScreen(navigationAction, eventViewModel = eventViewModel)
+      HomeScreen(navigationAction, eventViewModel = eventViewModel, searchViewModel = searchViewModel)
     }
 
     // Ensure the 'Following' tab exists and perform a click.

--- a/app/src/androidTest/java/com/android/unio/screen/EventListOverviewTest.kt
+++ b/app/src/androidTest/java/com/android/unio/screen/EventListOverviewTest.kt
@@ -24,9 +24,7 @@ import io.mockk.spyk
 import com.android.unio.ui.navigation.TopLevelDestination
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/androidTest/java/com/android/unio/screen/EventListOverviewTest.kt
+++ b/app/src/androidTest/java/com/android/unio/screen/EventListOverviewTest.kt
@@ -10,21 +10,21 @@ import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepository
 import com.android.unio.model.event.EventRepositoryMock
 import com.android.unio.model.event.EventViewModel
+import com.android.unio.model.image.ImageRepositoryFirebaseStorage
 import com.android.unio.model.search.SearchRepository
 import com.android.unio.model.search.SearchViewModel
-import com.android.unio.model.image.ImageRepositoryFirebaseStorage
 import com.android.unio.model.user.UserRepositoryFirestore
 import com.android.unio.model.user.UserViewModel
 import com.android.unio.ui.home.HomeScreen
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.navigation.Screen
-import io.mockk.MockKAnnotations
-import io.mockk.impl.annotations.MockK
-import io.mockk.spyk
 import com.android.unio.ui.navigation.TopLevelDestination
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import io.mockk.MockKAnnotations
 import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.spyk
 import io.mockk.verify
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -58,8 +58,8 @@ class EventListOverviewTest {
   @Before
   fun setUp() {
     MockKAnnotations.init(this)
-      hiltRule.inject()
-      searchViewModel = spyk(SearchViewModel(searchRepository))
+    hiltRule.inject()
+    searchViewModel = spyk(SearchViewModel(searchRepository))
     every { navigationAction.navigateTo(any(TopLevelDestination::class)) } returns Unit
     every { navigationAction.navigateTo(any(String::class)) } returns Unit
     userViewModel = UserViewModel(userRepository)

--- a/app/src/androidTest/java/com/android/unio/ui/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/BottomNavigationTest.kt
@@ -54,7 +54,9 @@ class BottomNavigationTest {
 
   @Test
   fun testBottomNavigationMenuDisplayed() {
-    composeTestRule.setContent { HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel) }
+    composeTestRule.setContent {
+      HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel)
+    }
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/unio/ui/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/BottomNavigationTest.kt
@@ -39,6 +39,7 @@ class BottomNavigationTest {
 
   @Before
   fun setUp() {
+    MockKAnnotations.init(this)
     eventRepository = mock { EventRepository::class.java }
     eventViewModel = EventViewModel(eventRepository)
 
@@ -48,15 +49,15 @@ class BottomNavigationTest {
     navHostController = mock { NavHostController::class.java }
     navigationAction = NavigationAction(navHostController)
 
-    MockKAnnotations.init(this)
     searchViewModel = spyk(SearchViewModel(searchRepository))
+
+    composeTestRule.setContent {
+      HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel)
+    }
   }
 
   @Test
   fun testBottomNavigationMenuDisplayed() {
-    composeTestRule.setContent {
-      HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel)
-    }
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/unio/ui/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/BottomNavigationTest.kt
@@ -15,8 +15,6 @@ import com.android.unio.ui.home.HomeScreen
 import com.android.unio.ui.navigation.NavigationAction
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
-import io.mockk.MockKAnnotations
-import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/androidTest/java/com/android/unio/ui/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/BottomNavigationTest.kt
@@ -6,11 +6,16 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.navigation.NavHostController
 import com.android.unio.model.event.EventRepository
 import com.android.unio.model.event.EventViewModel
+import com.android.unio.model.search.SearchRepository
+import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.user.UserRepository
 import com.android.unio.model.user.UserRepositoryFirestore
 import com.android.unio.model.user.UserViewModel
 import com.android.unio.ui.home.HomeScreen
 import com.android.unio.ui.navigation.NavigationAction
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import io.mockk.spyk
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -29,6 +34,9 @@ class BottomNavigationTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  private lateinit var searchViewModel: SearchViewModel
+  @MockK(relaxed = true) private lateinit var searchRepository: SearchRepository
+
   @Before
   fun setUp() {
     eventRepository = mock { EventRepository::class.java }
@@ -39,11 +47,14 @@ class BottomNavigationTest {
 
     navHostController = mock { NavHostController::class.java }
     navigationAction = NavigationAction(navHostController)
+
+    MockKAnnotations.init(this)
+    searchViewModel = spyk(SearchViewModel(searchRepository))
   }
 
   @Test
   fun testBottomNavigationMenuDisplayed() {
-    composeTestRule.setContent { HomeScreen(navigationAction, eventViewModel, userViewModel) }
+    composeTestRule.setContent { HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel) }
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
@@ -49,8 +49,6 @@ class ScreenDisplayingTest {
   private lateinit var navigationAction: NavigationAction
   private lateinit var userViewModel: UserViewModel
 
-  @MockK private lateinit var searchRepository: SearchRepository
-  @MockK private lateinit var searchViewModel: SearchViewModel
   @MockK private lateinit var eventRepository: EventRepositoryFirestore
   private lateinit var eventViewModel: EventViewModel
   @MockK private lateinit var associationViewModel: AssociationViewModel
@@ -64,9 +62,13 @@ class ScreenDisplayingTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  private lateinit var searchViewModel: SearchViewModel
+  @MockK(relaxed = true) private lateinit var searchRepository: SearchRepository
+
   @Before
   fun setUp() {
     MockKAnnotations.init(this, relaxed = true)
+    searchViewModel = spyk(SearchViewModel(searchRepository))
 
     navigationAction = mock { NavHostController::class.java }
     userViewModel = mockk()
@@ -120,7 +122,7 @@ class ScreenDisplayingTest {
 
   @Test
   fun testHomeDisplayed() {
-    composeTestRule.setContent { HomeScreen(navigationAction, eventViewModel) }
+    composeTestRule.setContent { HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel) }
     composeTestRule.onNodeWithTag("HomeScreen").assertIsDisplayed()
   }
 

--- a/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
@@ -122,8 +122,12 @@ class ScreenDisplayingTest {
 
   @Test
   fun testHomeDisplayed() {
-    composeTestRule.setContent { HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel) }
+    composeTestRule.setContent {
+      HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel)
+    }
     composeTestRule.onNodeWithTag("HomeScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("searchBarInput").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -117,7 +117,8 @@ fun UnioApp(authViewModel: AuthViewModel) {
     }
     navigation(startDestination = Screen.HOME, route = Route.HOME) {
       composable(Screen.HOME) {
-        HomeScreen(navigationActions, eventViewModel, userViewModel = userViewModel)
+        HomeScreen(
+            navigationActions, eventViewModel, userViewModel = userViewModel, searchViewModel)
       }
       composable(Screen.EVENT_DETAILS) { navBackStackEntry ->
         // Get the event UID from the arguments

--- a/app/src/main/java/com/android/unio/model/search/SearchViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/search/SearchViewModel.kt
@@ -81,7 +81,6 @@ class SearchViewModel(private val repository: SearchRepository) : ViewModel() {
         SearchType.EVENT -> clearEvents()
         SearchType.ASSOCIATION -> clearAssociations()
       }
-
     } else {
       searchJob =
           viewModelScope.launch {

--- a/app/src/main/java/com/android/unio/model/search/SearchViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/search/SearchViewModel.kt
@@ -100,7 +100,6 @@ class SearchViewModel @Inject constructor(private val repository: SearchReposito
   private fun clearAssociations() {
     _associations.value = emptyList()
     status.value = Status.IDLE
-    Log.d("SearchViewModel", status.value.toString())
   }
 
   private fun clearEvents() {

--- a/app/src/main/java/com/android/unio/model/search/SearchViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/search/SearchViewModel.kt
@@ -1,7 +1,6 @@
 package com.android.unio.model.search
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -85,7 +85,7 @@ fun ExploreScreenContent(
     searchViewModel: SearchViewModel
 ) {
   val associationsByCategory by associationViewModel.associationsByCategory.collectAsState()
-  val searchQuery = remember { mutableStateOf("") }
+  var searchQuery by remember { mutableStateOf("") }
   var expanded by rememberSaveable { mutableStateOf(false) }
   val assocationResults by searchViewModel.associations.collectAsState()
   val searchState by searchViewModel.status.collectAsState()
@@ -107,9 +107,9 @@ fun ExploreScreenContent(
             inputField = {
               SearchBarDefaults.InputField(
                   modifier = Modifier.testTag("searchBarInput"),
-                  query = searchQuery.value,
+                  query = searchQuery,
                   onQueryChange = {
-                    searchQuery.value = it
+                    searchQuery = it
                     searchViewModel.debouncedSearch(it)
                   },
                   onSearch = {},

--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -110,7 +110,7 @@ fun ExploreScreenContent(
                   query = searchQuery,
                   onQueryChange = {
                     searchQuery = it
-                    searchViewModel.debouncedSearch(it)
+                    searchViewModel.debouncedSearch(it, SearchViewModel.SearchType.ASSOCIATION)
                   },
                   onSearch = {},
                   expanded = expanded,

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -181,7 +181,7 @@ fun HomeScreen(
           DockedSearchBar(
               inputField = {
                 SearchBarDefaults.InputField(
-                    //                        modifier = Modifier.testTag("searchBarInput"),
+                    modifier = Modifier.testTag("searchBarInput"),
                     query = searchQuery,
                     onQueryChange = {
                       searchQuery = it
@@ -192,19 +192,12 @@ fun HomeScreen(
                     onExpandedChange = {},
                     placeholder = {
                       Text(text = context.getString(R.string.explore_search_placeholder))
-                      //                                modifier =
-                      // Modifier.testTag("searchPlaceHolder"))
                     },
                     trailingIcon = {
                       if (searchState == SearchViewModel.Status.LOADING) {
                         CircularProgressIndicator()
                       } else {
-                        Icon(
-                            Icons.Default.Search,
-                            contentDescription = "Search icon",
-                            //                                    modifier =
-                            // Modifier.testTag("searchTrailingIcon")
-                        )
+                        Icon(Icons.Default.Search, contentDescription = "Search icon")
                       }
                     },
                 )
@@ -221,10 +214,7 @@ fun HomeScreen(
               Box(
                   modifier = Modifier.fillMaxSize().padding(paddingValues),
                   contentAlignment = Alignment.Center) {
-                    Text(
-                        //                           modifier =
-                        // Modifier.testTag("event_emptyEventPrompt"),
-                        text = "No events found.")
+                    Text(text = "No events found.")
                   }
             } else {
               LazyColumn(

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -214,7 +214,7 @@ fun HomeScreen(
               Box(
                   modifier = Modifier.fillMaxSize().padding(paddingValues),
                   contentAlignment = Alignment.Center) {
-                    Text(text = "No events found.")
+                    Text(context.getString(R.string.explore_search_no_results))
                   }
             } else {
               LazyColumn(
@@ -239,7 +239,7 @@ fun HomeScreen(
                 contentAlignment = Alignment.Center) {
                   Text(
                       modifier = Modifier.testTag("event_emptyEventPrompt"),
-                      text = "No events available.")
+                      text = context.getString(R.string.event_no_events_available))
                 }
           }
         }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -11,6 +11,7 @@
     <string name="event_tab_following">Suivis</string>
     <string name="event_add_event">Ajouter un évènement</string>
     <string name="event_no_events_available">Aucun évènement disponible.</string>
+    <string name="event_search_no_results">Aucun évènement trouvé.</string>
 
     <!-- Event Card Strings -->
     <string name="event_event_title">Titre de lévènement</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="event_tab_following">Following</string>
     <string name="event_add_event">Add Event</string>
     <string name="event_no_events_available">No events available.</string>
+    <string name="event_search_no_results">"No events found."</string>
 
     <!-- Event Card Strings -->
     <string name="event_event_title">Event Title</string>


### PR DESCRIPTION
This PR changes the Home screen and adds a search bar which allows the user to search for a specific event by keyword. It is quite similar in how it works to the Search front end for the explore associations page, but displays the events found as EventCard instead of list items like in the Associations. I've also refactored the SearchViewModel's searchDebounced function to allow it to work for events and associations, and potentially any other type of document we'd like to search on. 