### PR TITLE
Refactor Association Profile and several other fixes

### DIFF
--- a/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
@@ -3,7 +3,6 @@ package com.android.unio.ui
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.navigation.NavHostController
 import com.android.unio.mocks.association.MockAssociation
 import com.android.unio.mocks.user.MockUser
 import com.android.unio.model.association.AssociationViewModel

--- a/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
@@ -3,9 +3,9 @@ package com.android.unio.ui
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.android.unio.mocks.association.MockAssociation
+import com.android.unio.mocks.user.MockUser
 import com.android.unio.model.association.AssociationViewModel
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepositoryFirestore
@@ -14,7 +14,7 @@ import com.android.unio.model.image.ImageRepositoryFirebaseStorage
 import com.android.unio.model.search.SearchRepository
 import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.user.UserViewModel
-import com.android.unio.ui.association.AssociationProfileScreen
+import com.android.unio.ui.association.AssociationProfileScaffold
 import com.android.unio.ui.authentication.AccountDetails
 import com.android.unio.ui.authentication.EmailVerificationScreen
 import com.android.unio.ui.authentication.WelcomeScreen
@@ -27,7 +27,7 @@ import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.saved.SavedScreen
 import com.android.unio.ui.settings.SettingsScreen
 import com.android.unio.ui.user.SomeoneElseUserProfileScreen
-import com.android.unio.ui.user.UserProfileScreen
+import com.android.unio.ui.user.UserProfileScreenScaffold
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.auth
@@ -69,7 +69,7 @@ class ScreenDisplayingTest {
     MockKAnnotations.init(this, relaxed = true)
 
     navigationAction = mock { NavHostController::class.java }
-    userViewModel = mockk()
+    userViewModel = mockk(relaxed = true)
     associationViewModel = mockk()
     eventRepository = mockk()
 
@@ -159,11 +159,8 @@ class ScreenDisplayingTest {
   @Test
   fun testAssociationProfileDisplayed() {
     composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          "1",
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
+      AssociationProfileScaffold(
+          MockAssociation.createMockAssociation(), navigationAction, userViewModel)
     }
     composeTestRule.onNodeWithTag("AssociationScreen").assertIsDisplayed()
   }
@@ -182,7 +179,9 @@ class ScreenDisplayingTest {
 
   @Test
   fun testUserProfileDisplayed() {
-    composeTestRule.setContent { UserProfileScreen(navigationAction) }
+    composeTestRule.setContent {
+      UserProfileScreenScaffold(MockUser.createMockUser(), navigationAction, false) {}
+    }
     composeTestRule.onNodeWithTag("UserProfileScreen").assertIsDisplayed()
   }
 

--- a/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.android.unio.mocks.association.MockAssociation
 import com.android.unio.mocks.event.MockEvent
@@ -22,6 +21,7 @@ import com.android.unio.model.user.UserViewModel
 import com.android.unio.ui.navigation.NavigationAction
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.FirebaseFirestore
+import io.mockk.mockk
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,6 +41,8 @@ class AssociationProfileTest {
   @Mock private lateinit var eventRepository: EventRepository
   private lateinit var associationViewModel: AssociationViewModel
 
+  private lateinit var userViewModel: UserViewModel
+
   private lateinit var associations: List<Association>
   private lateinit var events: List<Event>
 
@@ -49,6 +51,8 @@ class AssociationProfileTest {
   @Before
   fun setUp() {
     MockitoAnnotations.openMocks(this)
+
+    userViewModel = mockk(relaxed = true)
 
     associations =
         listOf(
@@ -77,11 +81,8 @@ class AssociationProfileTest {
   @Test
   fun testAssociationProfileDisplayComponent() {
     composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          "1",
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
+      AssociationProfileScaffold(
+          MockAssociation.createMockAssociation(), navigationAction, userViewModel)
     }
     composeTestRule.waitForIdle()
 
@@ -96,8 +97,6 @@ class AssociationProfileTest {
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationFollowButton"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationDescription"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationEventTitle"))
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationEventCard-a"))
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationSeeMoreButton"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationContactMembersTitle"))
     assertDisplayComponentInScroll(
         composeTestRule.onNodeWithTag("AssociationRecruitmentDescription"))
@@ -114,11 +113,8 @@ class AssociationProfileTest {
   @Test
   fun testButtonBehavior() {
     composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          "1",
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
+      AssociationProfileScaffold(
+          MockAssociation.createMockAssociation(), navigationAction, userViewModel)
     }
     // Share button
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("associationShareButton"))
@@ -129,11 +125,6 @@ class AssociationProfileTest {
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationFollowButton"))
     composeTestRule.onNodeWithTag("AssociationFollowButton").performClick()
     assertSnackBarIsDisplayed()
-
-    // See more button
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationSeeMoreButton"))
-    composeTestRule.onNodeWithTag("AssociationSeeMoreButton").performClick()
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationEventCard-b"))
 
     // Roles buttons
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationTreasurerRoles"))
@@ -153,11 +144,8 @@ class AssociationProfileTest {
   @Test
   fun testGoBackButton() {
     composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          "",
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
+      AssociationProfileScaffold(
+          MockAssociation.createMockAssociation(), navigationAction, userViewModel)
     }
 
     composeTestRule.onNodeWithTag("goBackButton").performClick()
@@ -168,79 +156,11 @@ class AssociationProfileTest {
   @Test
   fun testAssociationProfileGoodId() {
     composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          "1",
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
+      AssociationProfileScaffold(
+          MockAssociation.createMockAssociation(), navigationAction, userViewModel)
     }
 
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationProfileTitle"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithText(this.associations.first().name))
-  }
-
-  @Test
-  fun testAssociationProfileBadId() {
-    composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          "IDONOTEXIST",
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
-    }
-
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("associationNotFound"))
-  }
-
-  @Test
-  fun testAssociationProfileEmptyUid() {
-    composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          "",
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
-    }
-
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("associationNotFound"))
-  }
-
-  @Test
-  fun testAssociationProfileSpecialCharacterUid() {
-    composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          MockAssociation.Companion.EdgeCaseUid.SPECIAL_CHARACTERS.value,
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
-    }
-
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationProfileTitle"))
-  }
-
-  @Test
-  fun testAssociationProfileLongUid() {
-    composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          MockAssociation.Companion.EdgeCaseUid.LONG.value,
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
-    }
-
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationProfileTitle"))
-  }
-
-  @Test
-  fun testAssociationProfileTypicalUid() {
-    composeTestRule.setContent {
-      AssociationProfileScreen(
-          navigationAction,
-          MockAssociation.Companion.EdgeCaseUid.TYPICAL.value,
-          associationViewModel,
-          userViewModel = viewModel(factory = UserViewModel.Factory))
-    }
-
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationProfileTitle"))
   }
 }

--- a/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
@@ -20,9 +20,6 @@ import com.android.unio.model.event.EventRepositoryFirestore
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
 import com.android.unio.model.user.UserViewModel
 import com.android.unio.ui.navigation.NavigationAction
-import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.FirebaseFirestore
-import io.mockk.mockk
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.MockKAnnotations
@@ -114,12 +111,6 @@ class AssociationProfileTest {
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationFollowButton"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationDescription"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationEventTitle"))
-    if (events.isNotEmpty()) {
-      assertDisplayComponentInScroll(
-          composeTestRule.onNodeWithTag(
-              "AssociationEventCard-" + events.sortedBy { it.date }[0].uid))
-    }
-    assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationSeeMoreButton"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationContactMembersTitle"))
     assertDisplayComponentInScroll(
         composeTestRule.onNodeWithTag("AssociationRecruitmentDescription"))

--- a/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/association/AssociationProfileTest.kt
@@ -179,4 +179,13 @@ class AssociationProfileTest {
     assertDisplayComponentInScroll(composeTestRule.onNodeWithTag("AssociationProfileTitle"))
     assertDisplayComponentInScroll(composeTestRule.onNodeWithText(this.associations.first().name))
   }
+
+  @Test
+  fun testAssociationProfileNoId() {
+    composeTestRule.setContent {
+      AssociationProfileScreen(navigationAction, associationViewModel, userViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("AssociationScreen").assertIsNotDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/android/unio/ui/explore/ExploreScreenTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/explore/ExploreScreenTest.kt
@@ -30,6 +30,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.verify
 
 class ExploreScreenTest {
@@ -152,8 +153,8 @@ class ExploreScreenTest {
     sortedByCategoryAssociations.forEach { (_, associations) ->
       associations.forEach {
         composeTestRule.onNodeWithTag("associationItem_${it.name}").performClick()
-        verify(navigationAction).navigateTo(Screen.withParams(Screen.ASSOCIATION_PROFILE, it.uid))
       }
     }
+    verify(navigationAction, atLeastOnce()).navigateTo(Screen.ASSOCIATION_PROFILE)
   }
 }

--- a/app/src/androidTest/java/com/android/unio/ui/user/UserProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/user/UserProfileTest.kt
@@ -2,11 +2,14 @@ package com.android.unio.ui.user
 
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import com.android.unio.mocks.user.MockUser
+import com.android.unio.model.user.UserRepositoryFirestore
+import com.android.unio.model.user.UserViewModel
 import com.android.unio.ui.navigation.NavigationAction
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
@@ -17,6 +20,8 @@ import org.junit.Test
 class UserProfileTest {
 
   @MockK private lateinit var navigationAction: NavigationAction
+  @MockK private lateinit var userRepository: UserRepositoryFirestore
+  private lateinit var userViewModel: UserViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -25,11 +30,13 @@ class UserProfileTest {
   @Before
   fun setUp() {
     MockKAnnotations.init(this)
+
+    userViewModel = UserViewModel(userRepository)
   }
 
   @Test
   fun testEverythingIsDisplayed() {
-    composeTestRule.setContent { UserProfileScreenContent(navigationAction, user) }
+    composeTestRule.setContent { UserProfileScreenScaffold(user, navigationAction, false) {} }
 
     composeTestRule.onNodeWithTag("UserProfilePicture").assertExists()
 
@@ -53,5 +60,12 @@ class UserProfileTest {
     composeTestRule.setContent { UserProfileBottomSheet(true, navigationAction) {} }
 
     composeTestRule.onNodeWithTag("UserProfileBottomSheet").assertIsDisplayed()
+  }
+
+  @Test
+  fun testNoUser() {
+    composeTestRule.setContent { UserProfileScreen(userViewModel, navigationAction) }
+
+    composeTestRule.onNodeWithTag("UserProfileScreen").assertIsNotDisplayed()
   }
 }

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -3,8 +3,6 @@ package com.android.unio
 import android.annotation.SuppressLint
 import android.content.pm.ActivityInfo
 import android.os.Bundle
-import android.util.Log
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -136,19 +134,8 @@ fun UnioApp(authViewModel: AuthViewModel) {
       composable(Screen.EXPLORE) {
         ExploreScreen(navigationActions, associationViewModel, searchViewModel)
       }
-      composable(Screen.ASSOCIATION_PROFILE) { navBackStackEntry ->
-        // Get the association UID from the arguments
-        val uid = navBackStackEntry.arguments?.getString("uid")
-
-        // Create the AssociationProfile screen with the association UID
-        uid?.let {
-          AssociationProfileScreen(
-              navigationActions, it, associationViewModel, userViewModel = userViewModel)
-        }
-            ?: run {
-              Log.e("AssociationProfile", "Association UID is null")
-              Toast.makeText(context, "Association UID is null", Toast.LENGTH_SHORT).show()
-            }
+      composable(Screen.ASSOCIATION_PROFILE) {
+        AssociationProfileScreen(navigationActions, associationViewModel, userViewModel)
       }
     }
     navigation(startDestination = Screen.SAVED, route = Route.SAVED) {

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -155,7 +155,7 @@ fun UnioApp(authViewModel: AuthViewModel) {
       composable(Screen.SAVED) { SavedScreen(navigationActions) }
     }
     navigation(startDestination = Screen.MY_PROFILE, route = Route.MY_PROFILE) {
-      composable(Screen.MY_PROFILE) { UserProfileScreen(navigationActions, userViewModel) }
+      composable(Screen.MY_PROFILE) { UserProfileScreen(userViewModel, navigationActions) }
       composable(Screen.SETTINGS) { SettingsScreen(navigationActions) }
     }
   }

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -6,7 +6,6 @@ import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -58,8 +57,6 @@ class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     super.onCreate(savedInstanceState)
-
-    val authViewModel: AuthViewModel by viewModels { AuthViewModel.Factory }
 
     setContent {
       Surface(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/android/unio/mocks/association/MockAssociation.kt
+++ b/app/src/main/java/com/android/unio/mocks/association/MockAssociation.kt
@@ -1,9 +1,12 @@
 package com.android.unio.mocks.association
 
+import com.android.unio.mocks.event.MockEvent
 import com.android.unio.mocks.firestore.MockReferenceList
 import com.android.unio.mocks.user.MockUser
 import com.android.unio.model.association.Association
 import com.android.unio.model.association.AssociationCategory
+import com.android.unio.model.event.Event
+import com.android.unio.model.firestore.ReferenceList
 import com.android.unio.model.user.User
 
 /**
@@ -76,7 +79,12 @@ class MockAssociation {
         category: AssociationCategory = AssociationCategory.ENTERTAINMENT,
         description: String = "This is the best description",
         image: String = "image1.png",
-        members: List<User> = emptyList()
+        members: List<User> = emptyList(),
+        events: ReferenceList<Event> =
+            MockReferenceList(
+                listOf(
+                    MockEvent.createMockEvent(
+                        associationDependency = true, userDependency = userDependency)))
     ): Association {
       val membersHelper =
           if (userDependency) {
@@ -94,7 +102,8 @@ class MockAssociation {
           description = description,
           members = MockReferenceList(membersHelper),
           image = image,
-          followersCount = 2)
+          followersCount = 2,
+          events = events)
     }
 
     fun createAllMockAssociations(

--- a/app/src/main/java/com/android/unio/model/association/Association.kt
+++ b/app/src/main/java/com/android/unio/model/association/Association.kt
@@ -5,13 +5,15 @@ import androidx.appsearch.annotation.Document.Id
 import androidx.appsearch.annotation.Document.Namespace
 import androidx.appsearch.annotation.Document.StringProperty
 import androidx.appsearch.app.AppSearchSchema.StringPropertyConfig
+import com.android.unio.model.event.Event
 import com.android.unio.model.firestore.ReferenceList
 import com.android.unio.model.strings.AssociationStrings
 import com.android.unio.model.user.User
 
 /**
- * Association data class Make sure to update the hydration and serialization methods when changing
- * the data class
+ * Association data class
+ *
+ * Make sure to update the hydration and serialization methods when changing the data class
  *
  * @property uid association id
  * @property url association url
@@ -22,6 +24,7 @@ import com.android.unio.model.user.User
  * @property followersCount number of association followers
  * @property members list of association members
  * @property image association image
+ * @property events list of association events
  */
 data class Association(
     val uid: String,
@@ -32,7 +35,8 @@ data class Association(
     val description: String,
     val followersCount: Int,
     val members: ReferenceList<User>,
-    var image: String
+    var image: String,
+    val events: ReferenceList<Event>
 ) {
   companion object
 }

--- a/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
@@ -28,6 +28,9 @@ class AssociationViewModel(
   val associationsByCategory: StateFlow<Map<AssociationCategory, List<Association>>> =
       _associationsByCategory
 
+  private val _selectedAssociation = MutableStateFlow<Association?>(null)
+  val selectedAssociation: StateFlow<Association?> = _selectedAssociation
+
   init {
     associationRepository.init { getAssociations() }
   }
@@ -108,5 +111,13 @@ class AssociationViewModel(
         ?.let {
           return it
         } ?: return null
+  }
+
+  fun selectAssociation(associationId: String) {
+    _selectedAssociation.value =
+        findAssociationById(associationId).also {
+          it?.events?.requestAll()
+          it?.members?.requestAll()
+        }
   }
 }

--- a/app/src/main/java/com/android/unio/model/authentication/AuthViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/authentication/AuthViewModel.kt
@@ -6,7 +6,6 @@ import com.android.unio.model.user.UserRepository
 import com.android.unio.ui.navigation.Route
 import com.android.unio.ui.navigation.Screen
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.auth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/android/unio/model/firestore/ReferenceList.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/ReferenceList.kt
@@ -12,7 +12,7 @@ interface ReferenceList<T> {
 
   fun remove(uid: String)
 
-  fun requestAll(onSuccess: () -> Unit)
+  fun requestAll(onSuccess: () -> Unit = {})
 
   fun contains(uid: String): Boolean
 }

--- a/app/src/main/java/com/android/unio/model/firestore/transform/Hydration.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Hydration.kt
@@ -20,6 +20,8 @@ fun AssociationRepositoryFirestore.Companion.hydrate(data: Map<String, Any>?): A
   val memberUids = data?.get("members") as? List<String> ?: emptyList()
   val members = User.firestoreReferenceListWith(memberUids)
 
+  val events = Event.firestoreReferenceListWith(data?.get("events") as? List<String> ?: emptyList())
+
   return Association(
       uid = data?.get("uid") as? String ?: "",
       url = data?.get("url") as? String ?: "",
@@ -31,7 +33,8 @@ fun AssociationRepositoryFirestore.Companion.hydrate(data: Map<String, Any>?): A
       description = data?.get("description") as? String ?: "",
       members = members,
       followersCount = data?.get("followersCount") as? Int ?: 0,
-      image = data?.get("image") as? String ?: "")
+      image = data?.get("image") as? String ?: "",
+      events = events)
 }
 
 fun UserRepositoryFirestore.Companion.hydrate(data: Map<String, Any>?): User {

--- a/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
@@ -17,7 +17,8 @@ fun AssociationRepositoryFirestore.Companion.serialize(association: Association)
       "description" to association.description,
       "members" to association.members.uids,
       "followersCount" to association.followersCount,
-      "image" to association.image)
+      "image" to association.image,
+      "events" to association.events.uids)
 }
 
 fun UserRepositoryFirestore.Companion.serialize(user: User): Map<String, Any> {

--- a/app/src/main/java/com/android/unio/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/user/UserViewModel.kt
@@ -37,7 +37,6 @@ class UserViewModel(val repository: UserRepository, initializeWithAuthenticatedU
     }
 
     _refreshState.value = true
-    _user.value = null
     repository.getUserWithId(
         uid,
         onSuccess = { fetchedUser ->

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -352,7 +352,6 @@ private fun AssociationEventCard(
     event: Event,
     userViewModel: UserViewModel
 ) {
-  println("AssociationEventCard-${event.uid}")
   Box(modifier = Modifier.testTag("AssociationEventCard-${event.uid}")) {
     EventCard(navigationAction = navigationAction, event = event, userViewModel = userViewModel)
   }

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -2,12 +2,12 @@ package com.android.unio.ui.association
 
 import android.content.Context
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -32,6 +32,7 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -50,7 +51,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.android.unio.R
 import com.android.unio.model.association.Association
@@ -63,6 +63,7 @@ import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.theme.AppTypography
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonNull.content
 
 // These variable are only here for testing purpose. They should be deleted when the screen is
 // linked to the backend
@@ -74,27 +75,18 @@ private var scope: CoroutineScope? = null
 @Composable
 fun AssociationProfileScreen(
     navigationAction: NavigationAction,
-    associationId: String,
-    associationViewModel: AssociationViewModel = viewModel(factory = AssociationViewModel.Factory),
+    associationViewModel: AssociationViewModel,
     userViewModel: UserViewModel
 ) {
-  val context = LocalContext.current
-  val association = associationViewModel.findAssociationById(associationId)
+  val association by associationViewModel.selectedAssociation.collectAsState()
+
   if (association == null) {
-    val error = context.getString(R.string.association_not_found)
-    Log.e("AssociationProfileScreen", error)
-    AssociationProfileScaffold(association = null, navigationAction = navigationAction) { padding ->
-      Column(modifier = Modifier.padding(padding)) {
-        Text(text = error, modifier = Modifier.testTag("associationNotFound"), color = Color.Red)
-      }
-    }
-  } else {
-    AssociationProfileScaffold(association = association, navigationAction = navigationAction) {
-        padding ->
-      AssociationProfileContent(
-          navigationAction, padding, association, associationViewModel, userViewModel, context)
-    }
+    Log.e("UnioApp", "Association UID not found in arguments")
+    Toast.makeText(LocalContext.current, "Association UID not found", Toast.LENGTH_SHORT).show()
+    return
   }
+
+  AssociationProfileScaffold(association!!, navigationAction, userViewModel)
 }
 
 /**
@@ -102,16 +94,16 @@ fun AssociationProfileScreen(
  * it contains the top bar, the content given in parameter and the snackbar host used on
  * unimplemented features.
  *
- * @param association (Association) : The association to display
- * @param navigationAction (NavigationAction) : The navigation actions of the screen
- * @param content (Composable) : The content of the screen
+ * @param association [Association] : The association to display
+ * @param navigationAction [NavigationAction] : The navigation actions of the screen
+ * @param userViewModel [UserViewModel] : The user view model
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AssociationProfileScaffold(
-    association: Association?,
+fun AssociationProfileScaffold(
+    association: Association,
     navigationAction: NavigationAction,
-    content: @Composable (padding: PaddingValues) -> Unit
+    userViewModel: UserViewModel
 ) {
   val context = LocalContext.current
   testSnackbar = remember { SnackbarHostState() }
@@ -121,7 +113,7 @@ private fun AssociationProfileScaffold(
         SnackbarHost(
             hostState = testSnackbar!!,
             modifier = Modifier.testTag("associationSnackbarHost"),
-            snackbar = { data ->
+            snackbar = {
               Snackbar {
                 TextButton(
                     onClick = { testSnackbar!!.currentSnackbarData?.dismiss() },
@@ -134,13 +126,7 @@ private fun AssociationProfileScaffold(
       topBar = {
         TopAppBar(
             title = {
-              val title: String
-              if (association != null) {
-                title = association.name
-              } else {
-                title = context.getString(R.string.association_not_found)
-              }
-              Text(text = title, modifier = Modifier.testTag("AssociationProfileTitle"))
+              Text(text = association.name, modifier = Modifier.testTag("AssociationProfileTitle"))
             },
             navigationIcon = {
               IconButton(
@@ -164,7 +150,13 @@ private fun AssociationProfileScaffold(
                   }
             })
       },
-      content = { padding -> content(padding) })
+      content = { padding ->
+        Surface(
+            modifier = Modifier.padding(padding),
+        ) {
+          AssociationProfileContent(navigationAction, association, userViewModel)
+        }
+      })
 }
 
 /**
@@ -172,42 +164,31 @@ private fun AssociationProfileScaffold(
  * elements that should be displayed on the screen, such as the header, the description, the events,
  * (...) separated by spacers.
  *
- * @param padding (PaddingValues) : The padding of the screen
- * @param association (Association) : The association to display
- * @param associationViewModel (AssociationViewModel) : The associations view model
- * @param context (Context) : The context of the screen
+ * @param navigationAction [NavigationAction] : The navigation actions of the screen
+ * @param association [Association] : The association to display
+ * @param userViewModel [UserViewModel] : The user view model
  */
 @Composable
 private fun AssociationProfileContent(
     navigationAction: NavigationAction,
-    padding: PaddingValues,
     association: Association,
-    associationViewModel: AssociationViewModel,
-    userViewModel: UserViewModel,
-    context: Context
+    userViewModel: UserViewModel
 ) {
-  Column(
-      modifier =
-          Modifier.padding(padding)
-              .testTag("AssociationScreen")
-              .verticalScroll(rememberScrollState())) {
-        AssociationHeader(association, context)
-        Spacer(modifier = Modifier.size(22.dp))
-        AssociationDescription(association)
-        Spacer(modifier = Modifier.size(15.dp))
-        AssociationEventTitle(context)
-        Spacer(modifier = Modifier.size(11.dp))
-        AssociationProfileEvents(
-            navigationAction,
-            association,
-            associationViewModel,
-            userViewModel = userViewModel,
-            context)
-        Spacer(modifier = Modifier.size(11.dp))
-        UsersCard(association.members.list.collectAsState().value, context)
-        Spacer(modifier = Modifier.size(61.dp))
-        AssociationRecruitment(association, context)
-      }
+  val context = LocalContext.current
+
+  Column(modifier = Modifier.testTag("AssociationScreen").verticalScroll(rememberScrollState())) {
+    AssociationHeader(association, context)
+    Spacer(modifier = Modifier.size(22.dp))
+    AssociationDescription(association)
+    Spacer(modifier = Modifier.size(15.dp))
+    AssociationEventTitle()
+    Spacer(modifier = Modifier.size(11.dp))
+    AssociationProfileEvents(navigationAction, association, userViewModel)
+    Spacer(modifier = Modifier.size(11.dp))
+    UsersCard(association.members.list.collectAsState().value)
+    Spacer(modifier = Modifier.size(61.dp))
+    AssociationRecruitment(association)
+  }
 }
 
 /**
@@ -219,10 +200,11 @@ private fun AssociationProfileContent(
  * implemented !!!
  *
  * @param association (Association) : The association currently displayed
- * @param context (Context) : The context of the screen
  */
 @Composable
-private fun AssociationRecruitment(association: Association, context: Context) {
+private fun AssociationRecruitment(association: Association) {
+  val context = LocalContext.current
+
   Text(
       text = context.getString(R.string.association_join) + " ${association.name} ?",
       style = AppTypography.headlineMedium,
@@ -267,10 +249,11 @@ private fun AssociationRecruitment(association: Association, context: Context) {
  * the title of the section and then display the different users in the association.
  *
  * @param userList (List<User>) : The list of users in the association that can be contacted
- * @param context (Context) : The context of the screen
  */
 @Composable
-private fun UsersCard(userList: List<User>, context: Context) {
+private fun UsersCard(userList: List<User>) {
+  val context = LocalContext.current
+
   Text(
       context.getString(R.string.association_contact_members),
       style = AppTypography.headlineMedium,
@@ -309,23 +292,22 @@ private fun UsersCard(userList: List<User>, context: Context) {
  * Component that display all the events of the association in a card format, like in the home
  * screen.
  *
+ * @param navigationAction (NavigationAction) : The navigation actions of the screen
  * @param association (Association) : The association currently displayed
- * @param associationViewModel (AssociationViewModel) : The associations view model
- * @param context (Context) : The context of the screen
+ * @param userViewModel (UserViewModel) : The user view model
  */
 @Composable
 private fun AssociationProfileEvents(
     navigationAction: NavigationAction,
     association: Association,
-    associationViewModel: AssociationViewModel,
-    userViewModel: UserViewModel,
-    context: Context
+    userViewModel: UserViewModel
 ) {
+  val context = LocalContext.current
+
   var isSeeMoreClicked by remember { mutableStateOf(false) }
-  var events = emptyList<Event>()
-  associationViewModel.getEventsForAssociation(association) { fetchedEvents ->
-    events = fetchedEvents
-  }
+
+  val events by association.events.list.collectAsState()
+
   if (events.isEmpty()) {
     Text(
         text = context.getString(R.string.association_no_event),
@@ -345,13 +327,17 @@ private fun AssociationProfileEvents(
           }
         }
     Spacer(modifier = Modifier.size(11.dp))
-    OutlinedButton(
-        onClick = { isSeeMoreClicked = true },
-        modifier = Modifier.padding(horizontal = 28.dp).testTag("AssociationSeeMoreButton")) {
-          Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "See more")
-          Spacer(Modifier.width(2.dp))
-          Text(context.getString(R.string.association_see_more))
-        }
+    if (events.size > 1) {
+      OutlinedButton(
+          onClick = { isSeeMoreClicked = true },
+          modifier = Modifier.padding(horizontal = 28.dp).testTag("AssociationSeeMoreButton")) {
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = context.getString(R.string.association_see_more))
+            Spacer(Modifier.width(2.dp))
+            Text(context.getString(R.string.association_see_more))
+          }
+    }
   }
 }
 
@@ -366,21 +352,16 @@ private fun AssociationEventCard(
     event: Event,
     userViewModel: UserViewModel
 ) {
+  println("AssociationEventCard-${event.uid}")
   Box(modifier = Modifier.testTag("AssociationEventCard-${event.uid}")) {
-    EventCard(
-        navigationAction = navigationAction,
-        event = Event(organisers = event.organisers, taggedAssociations = event.taggedAssociations),
-        userViewModel = userViewModel)
+    EventCard(navigationAction = navigationAction, event = event, userViewModel = userViewModel)
   }
 }
 
-/**
- * Component that introduce the upcoming events of the association.
- *
- * @param context (Context) : The context of the screen
- */
+/** Component that introduces the upcoming events of the association. */
 @Composable
-private fun AssociationEventTitle(context: Context) {
+private fun AssociationEventTitle() {
+  val context = LocalContext.current
   Text(
       context.getString(R.string.association_upcoming_events),
       modifier = Modifier.padding(horizontal = 20.dp).testTag("AssociationEventTitle"),
@@ -426,8 +407,7 @@ private fun AssociationHeader(association: Association, context: Context) {
           style = AppTypography.headlineSmall,
           modifier = Modifier.padding(bottom = 5.dp).testTag("AssociationHeaderFollowers"))
       Text(
-          "${association.members.list.collectAsState().value.size} " +
-              context.getString(R.string.association_member),
+          "${association.members.uids.size} " + context.getString(R.string.association_member),
           style = AppTypography.headlineSmall,
           modifier = Modifier.padding(bottom = 14.dp).testTag("AssociationHeaderMembers"))
       Button(

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -63,7 +63,6 @@ import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.theme.AppTypography
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.JsonNull.content
 
 // These variable are only here for testing purpose. They should be deleted when the screen is
 // linked to the backend

--- a/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
@@ -52,7 +52,9 @@ import coil.compose.AsyncImage
 import com.android.unio.R
 import com.android.unio.model.association.Association
 import com.android.unio.model.association.AssociationCategory
+import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventViewModel
+import com.android.unio.model.firestore.emptyFirestoreReferenceList
 import com.android.unio.model.firestore.firestoreReferenceListWith
 import com.android.unio.model.user.User
 import com.android.unio.model.user.UserViewModel
@@ -97,7 +99,8 @@ fun EventScreen(
                   "ACM is the world's largest educational and scientific computing society.",
               members = User.firestoreReferenceListWith(listOf("1", "2")),
               image = "https://www.example.com/image.jpg",
-              followersCount = 0),
+              followersCount = 0,
+              events = Event.emptyFirestoreReferenceList()),
           Association(
               uid = "2",
               url = "https://www.ieee.org/",
@@ -108,7 +111,8 @@ fun EventScreen(
                   "IEEE is the world's largest technical professional organization dedicated to advancing technology for the benefit of humanity.",
               members = User.firestoreReferenceListWith(listOf("3", "4")),
               image = "https://www.example.com/image.jpg",
-              followersCount = 0))
+              followersCount = 0,
+              events = Event.emptyFirestoreReferenceList()))
 
   val context = LocalContext.current
   testSnackbar = remember { SnackbarHostState() }

--- a/app/src/main/java/com/android/unio/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/unio/ui/explore/Explore.kt
@@ -203,7 +203,11 @@ fun ExploreScreenContent(
                     horizontalArrangement = Arrangement.spacedBy(32.dp, Alignment.Start),
                     verticalAlignment = Alignment.CenterVertically) {
                       items(alphabeticalAssociations.size) { index ->
-                        AssociationItem(alphabeticalAssociations[index], navigationAction)
+                        AssociationItem(alphabeticalAssociations[index]) {
+                          associationViewModel.selectAssociation(
+                              alphabeticalAssociations[index].uid)
+                          navigationAction.navigateTo(Screen.ASSOCIATION_PROFILE)
+                        }
                       }
                     }
               }
@@ -221,14 +225,10 @@ fun ExploreScreenContent(
  * @param navigationAction The navigation action to use when the item is clicked.
  */
 @Composable
-fun AssociationItem(association: Association, navigationAction: NavigationAction) {
+fun AssociationItem(association: Association, onClick: () -> Unit) {
   Column(
       modifier =
-          Modifier.clickable {
-                navigationAction.navigateTo(
-                    Screen.withParams(Screen.ASSOCIATION_PROFILE, association.uid))
-              }
-              .testTag("associationItem_${association.name}")) {
+          Modifier.clickable(onClick = onClick).testTag("associationItem_${association.name}")) {
         /**
          * AdEC image is used as the placeholder. Will need to add the actual image later, when the
          * actual view model is used.

--- a/app/src/main/java/com/android/unio/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/com/android/unio/ui/navigation/NavigationAction.kt
@@ -99,7 +99,7 @@ object Screen {
   const val SAVED = "Saved Screen"
   const val MY_PROFILE = "MyProfile Screen"
   const val SETTINGS = "Settings"
-  const val ASSOCIATION_PROFILE = "Association Profile Screen/{uid}"
+  const val ASSOCIATION_PROFILE = "Association Profile Screen"
   const val EVENT_DETAILS = "Event Details Screen/{uid}"
 
   /**

--- a/app/src/main/java/com/android/unio/ui/user/UserProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/user/UserProfile.kt
@@ -1,6 +1,5 @@
 package com.android.unio.ui.user
 
-import android.annotation.SuppressLint
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
@@ -72,7 +71,6 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import kotlinx.coroutines.launch
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun UserProfileScreen(userViewModel: UserViewModel, navigationAction: NavigationAction) {
 

--- a/app/src/main/java/com/android/unio/ui/user/UserProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/user/UserProfile.kt
@@ -228,9 +228,7 @@ fun UserProfileScreenContent(navigationAction: NavigationAction, user: User) {
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
               joinedAssociations.map {
-                AssociationSmall(it) {
-                  navigationAction.navigateTo(Screen.withParams(Screen.ASSOCIATION_PROFILE, it.uid))
-                }
+                AssociationSmall(it) { navigationAction.navigateTo(Screen.ASSOCIATION_PROFILE) }
               }
             }
           }
@@ -245,9 +243,7 @@ fun UserProfileScreenContent(navigationAction: NavigationAction, user: User) {
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
               followedAssociations.map {
-                AssociationSmall(it) {
-                  navigationAction.navigateTo(Screen.withParams(Screen.ASSOCIATION_PROFILE, it.uid))
-                }
+                AssociationSmall(it) { navigationAction.navigateTo(Screen.ASSOCIATION_PROFILE) }
               }
             }
           }

--- a/app/src/main/java/com/android/unio/ui/user/UserProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/user/UserProfile.kt
@@ -1,6 +1,7 @@
 package com.android.unio.ui.user
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -57,7 +58,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.android.unio.model.user.User
 import com.android.unio.model.user.UserViewModel
@@ -72,20 +72,32 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun UserProfileScreen(
-    navigationAction: NavigationAction,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
-) {
+fun UserProfileScreen(userViewModel: UserViewModel, navigationAction: NavigationAction) {
 
   val user by userViewModel.user.collectAsState()
 
+  if (user == null) {
+    Log.e("UserProfileScreen", "User is null.")
+    Toast.makeText(LocalContext.current, "An error occurred.", Toast.LENGTH_SHORT).show()
+    return
+  }
+
   val refreshState by userViewModel.refreshState
-  val pullRefreshState =
-      rememberPullRefreshState(
-          refreshing = refreshState, onRefresh = { userViewModel.refreshUser() })
+
+  UserProfileScreenScaffold(user!!, navigationAction, refreshState) { userViewModel.refreshUser() }
+}
+
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun UserProfileScreenScaffold(
+    user: User,
+    navigationAction: NavigationAction,
+    refreshState: Boolean,
+    onRefresh: () -> Unit
+) {
+  val pullRefreshState = rememberPullRefreshState(refreshing = refreshState, onRefresh = onRefresh)
 
   var showSheet by remember { mutableStateOf(false) }
 
@@ -104,7 +116,7 @@ fun UserProfileScreen(
         BottomNavigationMenu(
             { navigationAction.navigateTo(it.route) }, LIST_TOP_LEVEL_DESTINATION, Route.MY_PROFILE)
       }) { padding ->
-        if (refreshState || user == null) {
+        if (refreshState) {
           Box(
               modifier = Modifier.fillMaxSize().background(Color.White).padding(padding),
               contentAlignment = Alignment.Center) {
@@ -117,7 +129,7 @@ fun UserProfileScreen(
                       .pullRefresh(pullRefreshState)
                       .fillMaxHeight()
                       .verticalScroll(rememberScrollState())) {
-                UserProfileScreenContent(navigationAction, user!!)
+                UserProfileScreenContent(navigationAction, user)
               }
         }
       }
@@ -132,7 +144,7 @@ fun UserProfileScreen(
   UserProfileBottomSheet(showSheet, navigationAction) { showSheet = false }
 }
 
-@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterialApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun UserProfileScreenContent(navigationAction: NavigationAction, user: User) {
 

--- a/app/src/test/java/com/android/unio/model/association/AssociationRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/unio/model/association/AssociationRepositoryFirestoreTest.kt
@@ -1,6 +1,7 @@
 package com.android.unio.model.association
 
 import com.android.unio.mocks.association.MockAssociation
+import com.android.unio.model.event.Event
 import com.android.unio.model.firestore.FirestorePaths.ASSOCIATION_PATH
 import com.android.unio.model.firestore.FirestorePaths.USER_PATH
 import com.android.unio.model.firestore.emptyFirestoreReferenceList
@@ -96,7 +97,8 @@ class AssociationRepositoryFirestoreTest {
             "description" to association1.description,
             "members" to association1.members.uids,
             "followersCount" to association1.followersCount,
-            "image" to association1.image)
+            "image" to association1.image,
+            "events" to association1.events.uids)
 
     map2 =
         mapOf(
@@ -108,7 +110,8 @@ class AssociationRepositoryFirestoreTest {
             "description" to association2.description,
             "members" to association2.members.uids,
             "followersCount" to association2.followersCount,
-            "image" to association2.image)
+            "image" to association2.image,
+            "events" to association2.events.uids)
 
     `when`(queryDocumentSnapshot1.data).thenReturn(map1)
     `when`(queryDocumentSnapshot2.data).thenReturn(map2)
@@ -153,7 +156,8 @@ class AssociationRepositoryFirestoreTest {
                   description = "",
                   members = User.emptyFirestoreReferenceList(),
                   followersCount = 0,
-                  image = "")
+                  image = "",
+                  events = Event.emptyFirestoreReferenceList())
 
           assertEquals(2, associations.size)
 

--- a/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
+++ b/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
@@ -47,7 +47,8 @@ class HydrationAndSerializationTest {
           description = "An example association",
           members = User.firestoreReferenceListWith(listOf("1", "2")),
           followersCount = 0,
-          image = "https://www.example.com/image.jpg")
+          image = "https://www.example.com/image.jpg",
+          events = Event.firestoreReferenceListWith(listOf("1", "2")))
 
   private val event =
       Event(
@@ -105,6 +106,7 @@ class HydrationAndSerializationTest {
     assertEquals(association.description, serialized["description"])
     assertEquals(association.members.uids, serialized["members"])
     assertEquals(association.image, serialized["image"])
+    assertEquals(association.events.uids, serialized["events"])
 
     val hydrated = AssociationRepositoryFirestore.hydrate(serialized)
 
@@ -115,6 +117,7 @@ class HydrationAndSerializationTest {
     assertEquals(association.description, hydrated.description)
     assertEquals(association.members.list.value, hydrated.members.list.value)
     assertEquals(association.image, hydrated.image)
+    assertEquals(association.events.list.value, hydrated.events.list.value)
   }
 
   @Test
@@ -179,8 +182,9 @@ class HydrationAndSerializationTest {
     assertEquals("", hydrated.name)
     assertEquals("", hydrated.fullName)
     assertEquals("", hydrated.description)
-    assertEquals(emptyList<String>(), hydrated.members.list.value)
+    assertEquals(emptyList<User>(), hydrated.members.list.value)
     assertEquals("", hydrated.image)
+    assertEquals(emptyList<Event>(), hydrated.events.list.value)
   }
 
   @Test
@@ -197,8 +201,8 @@ class HydrationAndSerializationTest {
     assertEquals(0.0, hydrated.price)
     assertEquals(Timestamp(0, 0), hydrated.date)
     assertEquals(Location(), hydrated.location)
-    assertEquals(emptyList<String>(), hydrated.organisers.list.value)
-    assertEquals(emptyList<String>(), hydrated.taggedAssociations.list.value)
+    assertEquals(emptyList<Association>(), hydrated.organisers.list.value)
+    assertEquals(emptyList<Association>(), hydrated.taggedAssociations.list.value)
   }
 
   /** Test that serialization includes all data class fields. */

--- a/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
@@ -82,7 +82,8 @@ class SearchRepositoryTest {
           description = "ACM is the world's largest educational and scientific computing society.",
           followersCount = 1,
           members = User.firestoreReferenceListWith(listOf("1", "2")),
-          image = "https://www.example.com/image.jpg")
+          image = "https://www.example.com/image.jpg",
+          events = Event.firestoreReferenceListWith(listOf("1", "2")))
 
   private val association2 =
       Association(
@@ -95,7 +96,8 @@ class SearchRepositoryTest {
               "IEEE is the world's largest technical professional organization dedicated to advancing technology for the benefit of humanity.",
           followersCount = 1,
           members = User.firestoreReferenceListWith(listOf("3", "4")),
-          image = "https://www.example.com/image.jpg")
+          image = "https://www.example.com/image.jpg",
+          events = Event.firestoreReferenceListWith(listOf("3", "4")))
 
   private val event1 =
       Event(

--- a/app/src/test/java/com/android/unio/ui/NavigationActionTest.kt
+++ b/app/src/test/java/com/android/unio/ui/NavigationActionTest.kt
@@ -65,10 +65,10 @@ class NavigationActionTest {
 
   @Test
   fun testScreenWithSingleParam() {
-    val screen = Screen.ASSOCIATION_PROFILE
+    val screen = "association/{uid}"
     val uid = "2024"
     val result = Screen.withParams(screen, uid)
-    val expected = Screen.ASSOCIATION_PROFILE.replace("{uid}", uid)
+    val expected = screen.replace("{uid}", uid)
     assertEquals(expected, result)
   }
 


### PR DESCRIPTION
The main objective of this pull request is to fix an issue that came with #104, where a backend request was made directly from a Composable's scope in `AssociationProfile`, which thus made Firestore requests at every composable refresh.
This issue is now fixed, along with a refactor of the `AssociationViewModel`. To keep consistency accross the project, the same refactor was reflected in in `UserProfile`.
The most notable change of the refactor is to remove the use of the string parameter `{uid}` of the association profile route. Instead, the association is stored in the `AssociationViewModel`. This was decided after discussing with @armouldr, who is currently implementing the same process for the `EventDetails`.