### PR TITLE
Feat/Home: Change Home page top bar menu

### DIFF
--- a/app/src/androidTest/java/com/android/unio/ui/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/home/HomeTest.kt
@@ -125,8 +125,8 @@ class HomeTest {
       HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel)
     }
 
-    composeTestRule.onNodeWithTag(HomeTestTags.TAB_SAVED).assertExists()
-    composeTestRule.onNodeWithTag(HomeTestTags.TAB_SAVED).performClick()
+    composeTestRule.onNodeWithTag(HomeTestTags.TAB_FOLLOWING).assertExists()
+    composeTestRule.onNodeWithTag(HomeTestTags.TAB_FOLLOWING).performClick()
 
     composeTestRule.onNodeWithTag(HomeTestTags.MAP_BUTTON).assertExists()
     composeTestRule.onNodeWithTag(HomeTestTags.MAP_BUTTON).performClick()

--- a/app/src/main/java/com/android/unio/model/strings/test_tags/HomeTestTags.kt
+++ b/app/src/main/java/com/android/unio/model/strings/test_tags/HomeTestTags.kt
@@ -3,10 +3,8 @@ package com.android.unio.model.strings.test_tags
 object HomeTestTags {
   const val MAP_BUTTON = "mapButton"
   const val SCREEN = "homeScreen"
-  const val HEADER = "header"
   const val TAB_ALL = "tabAll"
-  const val TAB_SAVED = "tabFollowing"
-  const val UNDERLYING_BAR = "underlyingBar"
+  const val TAB_FOLLOWING = "tabFollowing"
   const val SEARCH_BAR_INPUT = "searchBarInput"
   const val SEARCH_BAR = "searchBar"
   const val EMPTY_EVENT_PROMPT = "emptyEventPrompt"

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -1,5 +1,6 @@
 package com.android.unio.ui.home
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -197,8 +198,18 @@ fun TopBar(
               Box(
                   modifier =
                       Modifier.fillMaxSize().drawBehind {
-                        val tabWidth = sizeList[0]!!.first
-                        val height = sizeList[0]!!.second
+                        val tabWidth: Float
+                        val height: Float
+                        if (sizeList[0] == null) {
+                          Log.e(
+                              "Home Page", "The size values of tabs are null, should not happen !")
+                          // hardcoded values in case sizeList[0] is null
+                          tabWidth = 576.0F
+                          height = 92.0F
+                        } else {
+                          tabWidth = sizeList[0]!!.first
+                          height = sizeList[0]!!.second
+                        }
                         val startOffset =
                             Offset(
                                 x = progressFromFirstPage * tabWidth + tabWidth / 3,

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -1,6 +1,5 @@
 package com.android.unio.ui.home
 
-import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -19,26 +18,35 @@ import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.android.unio.R
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventViewModel
@@ -51,8 +59,8 @@ import com.android.unio.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.navigation.Route
 import com.android.unio.ui.navigation.Screen
+import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     navigationAction: NavigationAction,
@@ -60,24 +68,11 @@ fun HomeScreen(
     userViewModel: UserViewModel,
     searchViewModel: SearchViewModel
 ) {
-
-    val density = LocalDensity.current.density
-
-    val coroutineScope = rememberCoroutineScope()
-    val animatablePosition = remember { Animatable(0f) }
-
-    var allTabWidth by remember { mutableStateOf(0.dp) }
-    var followingTabWidth by remember { mutableStateOf(0.dp) }
-    var allTabXCoordinate by remember { mutableStateOf(0f) }
-    var followingTabXCoordinate by remember { mutableStateOf(0f) }
-
-    val horizontalHeaderPadding = 16.dp
     val context = LocalContext.current
-
-    var searchQuery by remember { mutableStateOf("") }
 
     val searchResults by searchViewModel.events.collectAsState()
     val searchState by searchViewModel.status.collectAsState()
+
 
     Scaffold(
         floatingActionButton = {
@@ -99,186 +94,29 @@ fun HomeScreen(
         },
         modifier = Modifier.testTag(HomeTestTags.SCREEN),
         content = { paddingValues ->
-            Column() {
 
-                val tabItems = listOf(
-                    "All", "Following"
-                )
-                var selectedTabIndex by remember {
-                    mutableIntStateOf(0)
-                }
-                val pagerState = rememberPagerState {
-                    tabItems.size
-                }
-                LaunchedEffect(key1 = selectedTabIndex) {
-                    pagerState.animateScrollToPage(selectedTabIndex)
-                }
-
-                LaunchedEffect(key1 = pagerState.currentPage, pagerState.isScrollInProgress) {
-                    if (!pagerState.isScrollInProgress)
-                        selectedTabIndex = pagerState.currentPage
-                }
-                Column(modifier = Modifier.fillMaxWidth()) {
-
-                    TabRow(selectedTabIndex = selectedTabIndex) {
-                        tabItems.forEachIndexed { index, tabItem ->
-
-                            Tab(
-                                selected = index == selectedTabIndex,
-                                onClick = {
-                                    selectedTabIndex = index
-                                },
-                                text = { Text(text = tabItem) },
-
-                                )
-                        }
-                    }
-                    DockedSearchBar(
-                        inputField = {
-                            SearchBarDefaults.InputField(
-                                modifier = Modifier.testTag(HomeTestTags.SEARCH_BAR_INPUT),
-                                query = searchQuery,
-                                onQueryChange = {
-                                    searchQuery = it
-                                    searchViewModel.debouncedSearch(
-                                        it,
-                                        SearchViewModel.SearchType.EVENT
-                                    )
-                                },
-                                onSearch = {},
-                                expanded = false,
-                                onExpandedChange = {},
-                                placeholder = {
-                                    Text(text = context.getString(R.string.explore_search_placeholder))
-                                },
-                                trailingIcon = {
-                                    if (searchState == SearchViewModel.Status.LOADING) {
-                                        CircularProgressIndicator()
-                                    } else {
-                                        Icon(
-                                            Icons.Default.Search,
-                                            contentDescription =
-                                            context.getString(R.string.home_content_description_search_icon)
-                                        )
-                                    }
-                                },
-                            )
-                        },
-                        expanded = false,
-                        onExpandedChange = {},
-                        modifier = Modifier
-                            .padding(horizontal = 16.dp)
-                            .testTag(HomeTestTags.SEARCH_BAR)
-                    ) {}
-
-                    HorizontalPager(
-                        state = pagerState, modifier = Modifier
-                            .fillMaxWidth()
-                    ) { index ->
-                        HomeContent(navigationAction, index, searchQuery, searchState, searchResults, userViewModel, eventViewModel, paddingValues)
-                    }
-                }
-
-            /*Column(modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)) {
-                // Sticky Header
-                Box(
-                    modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 16.dp, horizontal = horizontalHeaderPadding)
-                        .testTag(HomeTestTags.HEADER)
-                ) {
-                    Column {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Text(
-                                text = "All",
-                                color =
-                                if (selectedTab == "All") MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.inversePrimary,
-                                modifier =
-                                Modifier
-                                    .clickable {
-                                        selectedTab = "All"
-                                        coroutineScope.launch {
-                                            animatablePosition.animateTo(
-                                                0f, // Starting point for "All"
-                                                animationSpec =
-                                                tween(durationMillis = 1000) // Animation duration
-                                            )
-                                        }
-                                    }
-                                    .padding(horizontal = 16.dp)
-                                    .onGloballyPositioned { coordinates ->
-                                        allTabWidth = (coordinates.size.width / density).dp
-                                        allTabXCoordinate = coordinates.positionInRoot().x
-                                    }
-                                    .testTag(HomeTestTags.TAB_ALL))
-
-                            // Clickable text for "Following"
-                            Text(
-                                text = "Following",
-                                color =
-                                if (selectedTab == "Following") MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.inversePrimary,
-                                modifier =
-                                Modifier
-                                    .clickable {
-                                        selectedTab = "Following"
-                                        coroutineScope.launch {
-                                            animatablePosition.animateTo(
-                                                1f, // Ending point for "Following"
-                                                animationSpec =
-                                                tween(durationMillis = 1000) // Animation duration
-                                            )
-                                        }
-                                    }
-                                    .padding(horizontal = 16.dp)
-                                    .onGloballyPositioned { coordinates ->
-                                        followingTabWidth = (coordinates.size.width / density).dp
-                                        followingTabXCoordinate = coordinates.positionInRoot().x
-                                    }
-                                    .testTag(HomeTestTags.TAB_SAVED))
-                        }
-
-                        // Underline to indicate selected tab with smooth sliding animation
-                        Box(modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 4.dp)) {
-                            val selectedTabWidth =
-                                if (selectedTab == "All") allTabWidth else followingTabWidth
-                            Box(
-                                modifier =
-                                Modifier
-                                    .offset(
-                                        x =
-                                        ((animatablePosition.value *
-                                                (followingTabXCoordinate - allTabXCoordinate) +
-                                                allTabXCoordinate) / density)
-                                            .dp - horizontalHeaderPadding
-                                    )
-                                    .width(selectedTabWidth)
-                                    .height(2.dp)
-                                    .background(Color.Blue)
-                                    .testTag(HomeTestTags.UNDERLYING_BAR)
-                            )
-                        }
-                    }
-                }*/
-
-
-
-
-            }})
-        }
+            TopBar(
+                navigationAction,
+                searchState,
+                searchResults,
+                userViewModel,
+                searchViewModel,
+                eventViewModel,
+                paddingValues
+            )
+        })
+}
 
 @Composable
-fun HomeContent(navigationAction:NavigationAction, topBarIndex: Int, searchQuery: String, searchState: SearchViewModel.Status, searchResults: List<Event>,
-                userViewModel: UserViewModel, eventViewModel: EventViewModel, paddingValues: PaddingValues) {
+fun HomeContent(
+    navigationAction: NavigationAction,
+    searchQuery: String,
+    searchState: SearchViewModel.Status,
+    searchResults: List<Event>,
+    userViewModel: UserViewModel,
+    eventViewModel: EventViewModel,
+    paddingValues: PaddingValues
+) {
 
     val context = LocalContext.current
     val events by eventViewModel.events.collectAsState()
@@ -317,8 +155,14 @@ fun HomeContent(navigationAction:NavigationAction, topBarIndex: Int, searchQuery
     }
 
 }
+
 @Composable
-fun EventList(navigationAction: NavigationAction,events: List<Event>, userViewModel: UserViewModel, eventViewModel: EventViewModel) {
+fun EventList(
+    navigationAction: NavigationAction,
+    events: List<Event>,
+    userViewModel: UserViewModel,
+    eventViewModel: EventViewModel
+) {
     LazyColumn(
         contentPadding = PaddingValues(vertical = 8.dp),
         modifier = Modifier
@@ -327,6 +171,157 @@ fun EventList(navigationAction: NavigationAction,events: List<Event>, userViewMo
     ) {
         items(events) { event ->
             EventCard(navigationAction, event, userViewModel, eventViewModel)
+        }
+    }
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopBar(
+    navigationAction: NavigationAction,
+    searchState: SearchViewModel.Status,
+    searchResults: List<Event>,
+    userViewModel: UserViewModel,
+    searchViewModel: SearchViewModel,
+    eventViewModel: EventViewModel,
+    paddingValues: PaddingValues
+) {
+
+
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier
+            .padding(paddingValues)
+            .padding(top = 20.dp, bottom = 50.dp)
+            .fillMaxSize()
+    ) {
+        var searchQuery by remember { mutableStateOf("") }
+
+        val list = listOf("All", "Following")
+        val scope = rememberCoroutineScope()
+        val pagerState = rememberPagerState(initialPage = 0) { 2 }
+
+        val sizeList = remember { mutableStateMapOf<Int, Pair<Float, Float>>() }
+
+        val progressFromFirstPage by remember {
+            derivedStateOf {
+                pagerState.currentPageOffsetFraction + pagerState.currentPage.dp.value
+            }
+        }
+        val colorScheme = MaterialTheme.colorScheme
+        TabRow(
+            selectedTabIndex = pagerState.currentPage,
+            contentColor = Color(0xFF362C28),
+            divider = {},
+            indicator = {
+                Box(modifier = Modifier
+                    .fillMaxSize()
+                    .drawBehind {
+
+                        val tabWidth = sizeList[0]!!.first
+                        val height = sizeList[0]!!.second
+                        val startOffset = Offset(
+                            x = progressFromFirstPage * tabWidth + tabWidth / 3,
+                            y = height - 25
+                        )
+                        val endOffset = Offset(
+                            x = progressFromFirstPage * tabWidth + tabWidth * 2 / 3,
+                            y = height - 25
+                        )
+
+                        drawLine(
+                            start = startOffset,
+                            end = endOffset,
+                            color = colorScheme.primary,
+                            strokeWidth = Stroke.DefaultMiter
+                        )
+
+                    }
+                )
+            }
+        ) {
+            list.forEachIndexed { index, str ->
+                Tab(
+                    selected = index == pagerState.currentPage,
+                    onClick = {
+                        scope.launch {
+                            pagerState.animateScrollToPage(index)
+                        }
+                    },
+                    modifier = Modifier
+                        .onSizeChanged {
+                            sizeList[index] = Pair(it.width.toFloat(), it.height.toFloat())
+                        },
+                    selectedContentColor = colorScheme.primary
+                ) {
+                    Text(
+                        text = str,
+                        style = TextStyle(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 12.sp,
+                        ),
+                        modifier = Modifier
+                            .align(CenterHorizontally)
+                            .padding(horizontal = 32.dp, vertical = 16.dp)
+                    )
+                }
+            }
+        }
+
+        DockedSearchBar(
+            inputField = {
+                SearchBarDefaults.InputField(
+                    modifier = Modifier.testTag(HomeTestTags.SEARCH_BAR_INPUT),
+                    query = searchQuery,
+                    onQueryChange = {
+                        searchQuery = it
+                        searchViewModel.debouncedSearch(
+                            it,
+                            SearchViewModel.SearchType.EVENT
+                        )
+                    },
+                    onSearch = {},
+                    expanded = false,
+                    onExpandedChange = {},
+                    placeholder = {
+                        Text(text = context.getString(R.string.explore_search_placeholder))
+                    },
+                    trailingIcon = {
+                        if (searchState == SearchViewModel.Status.LOADING) {
+                            CircularProgressIndicator()
+                        } else {
+                            Icon(
+                                Icons.Default.Search,
+                                contentDescription =
+                                context.getString(R.string.home_content_description_search_icon)
+                            )
+                        }
+                    },
+                )
+            },
+            expanded = false,
+            onExpandedChange = {},
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .testTag(HomeTestTags.SEARCH_BAR)
+        ) {}
+
+
+        HorizontalPager(
+            state = pagerState, modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            HomeContent(
+                navigationAction,
+                searchQuery,
+                searchState,
+                searchResults,
+                userViewModel,
+                eventViewModel,
+                paddingValues
+            )
         }
     }
 }

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -1,22 +1,16 @@
 package com.android.unio.ui.home
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Search
@@ -25,27 +19,28 @@ import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.unio.R
+import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.strings.test_tags.HomeTestTags
@@ -56,7 +51,6 @@ import com.android.unio.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.navigation.Route
 import com.android.unio.ui.navigation.Screen
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -66,188 +60,273 @@ fun HomeScreen(
     userViewModel: UserViewModel,
     searchViewModel: SearchViewModel
 ) {
-  val events by eventViewModel.events.collectAsState()
-  var selectedTab by remember { mutableStateOf("All") }
-  val density = LocalDensity.current.density
 
-  val coroutineScope = rememberCoroutineScope()
-  val animatablePosition = remember { Animatable(0f) }
+    val density = LocalDensity.current.density
 
-  var allTabWidth by remember { mutableStateOf(0.dp) }
-  var followingTabWidth by remember { mutableStateOf(0.dp) }
-  var allTabXCoordinate by remember { mutableStateOf(0f) }
-  var followingTabXCoordinate by remember { mutableStateOf(0f) }
+    val coroutineScope = rememberCoroutineScope()
+    val animatablePosition = remember { Animatable(0f) }
 
-  val horizontalHeaderPadding = 16.dp
+    var allTabWidth by remember { mutableStateOf(0.dp) }
+    var followingTabWidth by remember { mutableStateOf(0.dp) }
+    var allTabXCoordinate by remember { mutableStateOf(0f) }
+    var followingTabXCoordinate by remember { mutableStateOf(0f) }
 
-  var searchQuery by remember { mutableStateOf("") }
-  val context = LocalContext.current
-  val searchResults by searchViewModel.events.collectAsState()
-  val searchState by searchViewModel.status.collectAsState()
+    val horizontalHeaderPadding = 16.dp
+    val context = LocalContext.current
 
-  Scaffold(
-      floatingActionButton = {
-        FloatingActionButton(
-            onClick = { navigationAction.navigateTo(Screen.MAP) },
-            modifier = Modifier.testTag(HomeTestTags.MAP_BUTTON)) {
-              Icon(
-                  imageVector = Icons.Filled.Place,
-                  contentDescription =
-                      context.getString(R.string.home_content_description_map_button))
+    var searchQuery by remember { mutableStateOf("") }
+
+    val searchResults by searchViewModel.events.collectAsState()
+    val searchState by searchViewModel.status.collectAsState()
+
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { navigationAction.navigateTo(Screen.MAP) },
+                modifier = Modifier.testTag(HomeTestTags.MAP_BUTTON)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Place,
+                    contentDescription =
+                    context.getString(R.string.home_content_description_map_button)
+                )
             }
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            { navigationAction.navigateTo(it.route) }, LIST_TOP_LEVEL_DESTINATION, Route.HOME)
-      },
-      modifier = Modifier.testTag(HomeTestTags.SCREEN),
-      content = { paddingValues ->
-        Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
-          // Sticky Header
-          Box(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .padding(vertical = 16.dp, horizontal = horizontalHeaderPadding)
-                      .testTag(HomeTestTags.HEADER)) {
-                Column {
-                  Row(
-                      modifier = Modifier.fillMaxWidth(),
-                      horizontalArrangement = Arrangement.SpaceBetween) {
-                        Text(
-                            text = "All",
-                            color =
+        },
+        bottomBar = {
+            BottomNavigationMenu(
+                { navigationAction.navigateTo(it.route) }, LIST_TOP_LEVEL_DESTINATION, Route.HOME
+            )
+        },
+        modifier = Modifier.testTag(HomeTestTags.SCREEN),
+        content = { paddingValues ->
+            Column() {
+
+                val tabItems = listOf(
+                    "All", "Following"
+                )
+                var selectedTabIndex by remember {
+                    mutableIntStateOf(0)
+                }
+                val pagerState = rememberPagerState {
+                    tabItems.size
+                }
+                LaunchedEffect(key1 = selectedTabIndex) {
+                    pagerState.animateScrollToPage(selectedTabIndex)
+                }
+
+                LaunchedEffect(key1 = pagerState.currentPage, pagerState.isScrollInProgress) {
+                    if (!pagerState.isScrollInProgress)
+                        selectedTabIndex = pagerState.currentPage
+                }
+                Column(modifier = Modifier.fillMaxWidth()) {
+
+                    TabRow(selectedTabIndex = selectedTabIndex) {
+                        tabItems.forEachIndexed { index, tabItem ->
+
+                            Tab(
+                                selected = index == selectedTabIndex,
+                                onClick = {
+                                    selectedTabIndex = index
+                                },
+                                text = { Text(text = tabItem) },
+
+                                )
+                        }
+                    }
+                    DockedSearchBar(
+                        inputField = {
+                            SearchBarDefaults.InputField(
+                                modifier = Modifier.testTag(HomeTestTags.SEARCH_BAR_INPUT),
+                                query = searchQuery,
+                                onQueryChange = {
+                                    searchQuery = it
+                                    searchViewModel.debouncedSearch(
+                                        it,
+                                        SearchViewModel.SearchType.EVENT
+                                    )
+                                },
+                                onSearch = {},
+                                expanded = false,
+                                onExpandedChange = {},
+                                placeholder = {
+                                    Text(text = context.getString(R.string.explore_search_placeholder))
+                                },
+                                trailingIcon = {
+                                    if (searchState == SearchViewModel.Status.LOADING) {
+                                        CircularProgressIndicator()
+                                    } else {
+                                        Icon(
+                                            Icons.Default.Search,
+                                            contentDescription =
+                                            context.getString(R.string.home_content_description_search_icon)
+                                        )
+                                    }
+                                },
+                            )
+                        },
+                        expanded = false,
+                        onExpandedChange = {},
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .testTag(HomeTestTags.SEARCH_BAR)
+                    ) {}
+
+                    HorizontalPager(
+                        state = pagerState, modifier = Modifier
+                            .fillMaxWidth()
+                    ) { index ->
+                        HomeContent(navigationAction, index, searchQuery, searchState, searchResults, userViewModel, eventViewModel, paddingValues)
+                    }
+                }
+
+            /*Column(modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)) {
+                // Sticky Header
+                Box(
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp, horizontal = horizontalHeaderPadding)
+                        .testTag(HomeTestTags.HEADER)
+                ) {
+                    Column {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = "All",
+                                color =
                                 if (selectedTab == "All") MaterialTheme.colorScheme.primary
                                 else MaterialTheme.colorScheme.inversePrimary,
-                            modifier =
-                                Modifier.clickable {
-                                      selectedTab = "All"
-                                      coroutineScope.launch {
-                                        animatablePosition.animateTo(
-                                            0f, // Starting point for "All"
-                                            animationSpec =
+                                modifier =
+                                Modifier
+                                    .clickable {
+                                        selectedTab = "All"
+                                        coroutineScope.launch {
+                                            animatablePosition.animateTo(
+                                                0f, // Starting point for "All"
+                                                animationSpec =
                                                 tween(durationMillis = 1000) // Animation duration
                                             )
-                                      }
+                                        }
                                     }
                                     .padding(horizontal = 16.dp)
                                     .onGloballyPositioned { coordinates ->
-                                      allTabWidth = (coordinates.size.width / density).dp
-                                      allTabXCoordinate = coordinates.positionInRoot().x
+                                        allTabWidth = (coordinates.size.width / density).dp
+                                        allTabXCoordinate = coordinates.positionInRoot().x
                                     }
                                     .testTag(HomeTestTags.TAB_ALL))
 
-                        // Clickable text for "Following"
-                        Text(
-                            text = "Following",
-                            color =
+                            // Clickable text for "Following"
+                            Text(
+                                text = "Following",
+                                color =
                                 if (selectedTab == "Following") MaterialTheme.colorScheme.primary
                                 else MaterialTheme.colorScheme.inversePrimary,
-                            modifier =
-                                Modifier.clickable {
-                                      selectedTab = "Following"
-                                      coroutineScope.launch {
-                                        animatablePosition.animateTo(
-                                            1f, // Ending point for "Following"
-                                            animationSpec =
+                                modifier =
+                                Modifier
+                                    .clickable {
+                                        selectedTab = "Following"
+                                        coroutineScope.launch {
+                                            animatablePosition.animateTo(
+                                                1f, // Ending point for "Following"
+                                                animationSpec =
                                                 tween(durationMillis = 1000) // Animation duration
                                             )
-                                      }
+                                        }
                                     }
                                     .padding(horizontal = 16.dp)
                                     .onGloballyPositioned { coordinates ->
-                                      followingTabWidth = (coordinates.size.width / density).dp
-                                      followingTabXCoordinate = coordinates.positionInRoot().x
+                                        followingTabWidth = (coordinates.size.width / density).dp
+                                        followingTabXCoordinate = coordinates.positionInRoot().x
                                     }
                                     .testTag(HomeTestTags.TAB_SAVED))
-                      }
+                        }
 
-                  // Underline to indicate selected tab with smooth sliding animation
-                  Box(modifier = Modifier.fillMaxWidth().padding(top = 4.dp)) {
-                    val selectedTabWidth =
-                        if (selectedTab == "All") allTabWidth else followingTabWidth
-                    Box(
-                        modifier =
-                            Modifier.offset(
-                                    x =
+                        // Underline to indicate selected tab with smooth sliding animation
+                        Box(modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp)) {
+                            val selectedTabWidth =
+                                if (selectedTab == "All") allTabWidth else followingTabWidth
+                            Box(
+                                modifier =
+                                Modifier
+                                    .offset(
+                                        x =
                                         ((animatablePosition.value *
                                                 (followingTabXCoordinate - allTabXCoordinate) +
                                                 allTabXCoordinate) / density)
-                                            .dp - horizontalHeaderPadding)
-                                .width(selectedTabWidth)
-                                .height(2.dp)
-                                .background(Color.Blue)
-                                .testTag(HomeTestTags.UNDERLYING_BAR))
-                  }
-                }
-              }
-
-          DockedSearchBar(
-              inputField = {
-                SearchBarDefaults.InputField(
-                    modifier = Modifier.testTag(HomeTestTags.SEARCH_BAR_INPUT),
-                    query = searchQuery,
-                    onQueryChange = {
-                      searchQuery = it
-                      searchViewModel.debouncedSearch(it, SearchViewModel.SearchType.EVENT)
-                    },
-                    onSearch = {},
-                    expanded = false,
-                    onExpandedChange = {},
-                    placeholder = {
-                      Text(text = context.getString(R.string.explore_search_placeholder))
-                    },
-                    trailingIcon = {
-                      if (searchState == SearchViewModel.Status.LOADING) {
-                        CircularProgressIndicator()
-                      } else {
-                        Icon(
-                            Icons.Default.Search,
-                            contentDescription =
-                                context.getString(R.string.home_content_description_search_icon))
-                      }
-                    },
-                )
-              },
-              expanded = false,
-              onExpandedChange = {},
-              modifier = Modifier.padding(horizontal = 16.dp).testTag(HomeTestTags.SEARCH_BAR)) {}
-
-          // Event List
-          if (searchQuery.isNotEmpty() &&
-              (searchState == SearchViewModel.Status.SUCCESS ||
-                  searchState == SearchViewModel.Status.LOADING)) {
-            if (searchResults.isEmpty()) {
-              Box(
-                  modifier = Modifier.fillMaxSize().padding(paddingValues),
-                  contentAlignment = Alignment.Center) {
-                    Text(context.getString(R.string.explore_search_no_results))
-                  }
-            } else {
-              LazyColumn(
-                  contentPadding = PaddingValues(vertical = 8.dp),
-                  modifier = Modifier.fillMaxSize().padding(horizontal = 32.dp)) {
-                    items(searchResults) { event ->
-                      EventCard(navigationAction, event, userViewModel, eventViewModel)
+                                            .dp - horizontalHeaderPadding
+                                    )
+                                    .width(selectedTabWidth)
+                                    .height(2.dp)
+                                    .background(Color.Blue)
+                                    .testTag(HomeTestTags.UNDERLYING_BAR)
+                            )
+                        }
                     }
-                  }
-            }
-          } else if (events.isNotEmpty()) {
-            LazyColumn(
-                contentPadding = PaddingValues(vertical = 8.dp),
-                modifier = Modifier.fillMaxSize().padding(horizontal = 32.dp)) {
-                  items(events) { event ->
-                    EventCard(navigationAction, event, userViewModel, eventViewModel)
-                  }
-                }
-          } else {
-            Box(
-                modifier = Modifier.fillMaxSize().padding(paddingValues),
-                contentAlignment = Alignment.Center) {
-                  Text(
-                      modifier = Modifier.testTag(HomeTestTags.EMPTY_EVENT_PROMPT),
-                      text = context.getString(R.string.event_no_events_available))
-                }
-          }
+                }*/
+
+
+
+
+            }})
         }
-      })
+
+@Composable
+fun HomeContent(navigationAction:NavigationAction, topBarIndex: Int, searchQuery: String, searchState: SearchViewModel.Status, searchResults: List<Event>,
+                userViewModel: UserViewModel, eventViewModel: EventViewModel, paddingValues: PaddingValues) {
+
+    val context = LocalContext.current
+    val events by eventViewModel.events.collectAsState()
+    // Event List
+    if (searchQuery.isNotEmpty() &&
+        (searchState == SearchViewModel.Status.SUCCESS ||
+                searchState == SearchViewModel.Status.LOADING)
+    ) {
+        if (searchResults.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(context.getString(R.string.explore_search_no_results))
+            }
+        } else {
+            EventList(navigationAction, searchResults, userViewModel, eventViewModel)
+        }
+    } else if (events.isNotEmpty()) {
+        EventList(navigationAction, events, userViewModel, eventViewModel)
+
+    } else {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                modifier = Modifier.testTag(HomeTestTags.EMPTY_EVENT_PROMPT),
+                text = context.getString(R.string.event_no_events_available)
+            )
+        }
+    }
+
+}
+@Composable
+fun EventList(navigationAction: NavigationAction,events: List<Event>, userViewModel: UserViewModel, eventViewModel: EventViewModel) {
+    LazyColumn(
+        contentPadding = PaddingValues(vertical = 8.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 32.dp)
+    ) {
+        items(events) { event ->
+            EventCard(navigationAction, event, userViewModel, eventViewModel)
+        }
+    }
 }

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
@@ -191,7 +190,7 @@ fun TopBar(
         // Tab Menu at the top of the page
         TabRow(
             selectedTabIndex = pagerState.currentPage,
-            contentColor = Color(0xFF362C28),
+            contentColor = colorScheme.primary,
             divider = {},
             indicator = {
               // method that draws the indicator bar below the tab menu

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -68,43 +68,37 @@ fun HomeScreen(
     userViewModel: UserViewModel,
     searchViewModel: SearchViewModel
 ) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    val searchResults by searchViewModel.events.collectAsState()
-    val searchState by searchViewModel.status.collectAsState()
+  val searchResults by searchViewModel.events.collectAsState()
+  val searchState by searchViewModel.status.collectAsState()
 
-
-    Scaffold(
-        floatingActionButton = {
-            FloatingActionButton(
-                onClick = { navigationAction.navigateTo(Screen.MAP) },
-                modifier = Modifier.testTag(HomeTestTags.MAP_BUTTON)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Place,
-                    contentDescription =
-                    context.getString(R.string.home_content_description_map_button)
-                )
+  Scaffold(
+      floatingActionButton = {
+        FloatingActionButton(
+            onClick = { navigationAction.navigateTo(Screen.MAP) },
+            modifier = Modifier.testTag(HomeTestTags.MAP_BUTTON)) {
+              Icon(
+                  imageVector = Icons.Filled.Place,
+                  contentDescription =
+                      context.getString(R.string.home_content_description_map_button))
             }
-        },
-        bottomBar = {
-            BottomNavigationMenu(
-                { navigationAction.navigateTo(it.route) }, LIST_TOP_LEVEL_DESTINATION, Route.HOME
-            )
-        },
-        modifier = Modifier.testTag(HomeTestTags.SCREEN),
-        content = { paddingValues ->
-
-            TopBar(
-                navigationAction,
-                searchState,
-                searchResults,
-                userViewModel,
-                searchViewModel,
-                eventViewModel,
-                paddingValues
-            )
-        })
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            { navigationAction.navigateTo(it.route) }, LIST_TOP_LEVEL_DESTINATION, Route.HOME)
+      },
+      modifier = Modifier.testTag(HomeTestTags.SCREEN),
+      content = { paddingValues ->
+        TopBar(
+            navigationAction,
+            searchState,
+            searchResults,
+            userViewModel,
+            searchViewModel,
+            eventViewModel,
+            paddingValues)
+      })
 }
 
 @Composable
@@ -118,42 +112,32 @@ fun HomeContent(
     paddingValues: PaddingValues
 ) {
 
-    val context = LocalContext.current
-    val events by eventViewModel.events.collectAsState()
-    // Event List
-    if (searchQuery.isNotEmpty() &&
-        (searchState == SearchViewModel.Status.SUCCESS ||
-                searchState == SearchViewModel.Status.LOADING)
-    ) {
-        if (searchResults.isEmpty()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(context.getString(R.string.explore_search_no_results))
-            }
-        } else {
-            EventList(navigationAction, searchResults, userViewModel, eventViewModel)
-        }
-    } else if (events.isNotEmpty()) {
-        EventList(navigationAction, events, userViewModel, eventViewModel)
-
+  val context = LocalContext.current
+  val events by eventViewModel.events.collectAsState()
+  // Event List
+  if (searchQuery.isNotEmpty() &&
+      (searchState == SearchViewModel.Status.SUCCESS ||
+          searchState == SearchViewModel.Status.LOADING)) {
+    if (searchResults.isEmpty()) {
+      Box(
+          modifier = Modifier.fillMaxSize().padding(paddingValues),
+          contentAlignment = Alignment.Center) {
+            Text(context.getString(R.string.explore_search_no_results))
+          }
     } else {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                modifier = Modifier.testTag(HomeTestTags.EMPTY_EVENT_PROMPT),
-                text = context.getString(R.string.event_no_events_available)
-            )
-        }
+      EventList(navigationAction, searchResults, userViewModel, eventViewModel)
     }
-
+  } else if (events.isNotEmpty()) {
+    EventList(navigationAction, events, userViewModel, eventViewModel)
+  } else {
+    Box(
+        modifier = Modifier.fillMaxSize().padding(paddingValues),
+        contentAlignment = Alignment.Center) {
+          Text(
+              modifier = Modifier.testTag(HomeTestTags.EMPTY_EVENT_PROMPT),
+              text = context.getString(R.string.event_no_events_available))
+        }
+  }
 }
 
 @Composable
@@ -163,18 +147,12 @@ fun EventList(
     userViewModel: UserViewModel,
     eventViewModel: EventViewModel
 ) {
-    LazyColumn(
-        contentPadding = PaddingValues(vertical = 8.dp),
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 32.dp)
-    ) {
-        items(events) { event ->
-            EventCard(navigationAction, event, userViewModel, eventViewModel)
-        }
-    }
+  LazyColumn(
+      contentPadding = PaddingValues(vertical = 8.dp),
+      modifier = Modifier.fillMaxSize().padding(horizontal = 32.dp)) {
+        items(events) { event -> EventCard(navigationAction, event, userViewModel, eventViewModel) }
+      }
 }
-
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -188,15 +166,12 @@ fun TopBar(
     paddingValues: PaddingValues
 ) {
 
+  val context = LocalContext.current
 
-    val context = LocalContext.current
-
-    Column(
-        modifier = Modifier
-            .padding(paddingValues)
-            .padding(top = 20.dp, bottom = 50.dp)
-            .fillMaxSize()
-    ) {
+  Column(
+      horizontalAlignment = CenterHorizontally,
+      modifier =
+          Modifier.padding(paddingValues).padding(top = 20.dp, bottom = 50.dp).fillMaxSize()) {
         var searchQuery by remember { mutableStateOf("") }
 
         val list = listOf("All", "Following")
@@ -206,9 +181,7 @@ fun TopBar(
         val sizeList = remember { mutableStateMapOf<Int, Pair<Float, Float>>() }
 
         val progressFromFirstPage by remember {
-            derivedStateOf {
-                pagerState.currentPageOffsetFraction + pagerState.currentPage.dp.value
-            }
+          derivedStateOf { pagerState.currentPageOffsetFraction + pagerState.currentPage.dp.value }
         }
         val colorScheme = MaterialTheme.colorScheme
         TabRow(
@@ -216,112 +189,91 @@ fun TopBar(
             contentColor = Color(0xFF362C28),
             divider = {},
             indicator = {
-                Box(modifier = Modifier
-                    .fillMaxSize()
-                    .drawBehind {
-
+              Box(
+                  modifier =
+                      Modifier.fillMaxSize().drawBehind {
                         val tabWidth = sizeList[0]!!.first
                         val height = sizeList[0]!!.second
-                        val startOffset = Offset(
-                            x = progressFromFirstPage * tabWidth + tabWidth / 3,
-                            y = height - 25
-                        )
-                        val endOffset = Offset(
-                            x = progressFromFirstPage * tabWidth + tabWidth * 2 / 3,
-                            y = height - 25
-                        )
+                        val startOffset =
+                            Offset(
+                                x = progressFromFirstPage * tabWidth + tabWidth / 3,
+                                y = height - 25)
+                        val endOffset =
+                            Offset(
+                                x = progressFromFirstPage * tabWidth + tabWidth * 2 / 3,
+                                y = height - 25)
 
                         drawLine(
                             start = startOffset,
                             end = endOffset,
                             color = colorScheme.primary,
-                            strokeWidth = Stroke.DefaultMiter
-                        )
-
-                    }
-                )
-            }
-        ) {
-            list.forEachIndexed { index, str ->
+                            strokeWidth = Stroke.DefaultMiter)
+                      })
+            }) {
+              list.forEachIndexed { index, str ->
                 Tab(
                     selected = index == pagerState.currentPage,
-                    onClick = {
-                        scope.launch {
-                            pagerState.animateScrollToPage(index)
-                        }
-                    },
-                    modifier = Modifier
-                        .onSizeChanged {
-                            sizeList[index] = Pair(it.width.toFloat(), it.height.toFloat())
+                    onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
+                    modifier =
+                        Modifier.onSizeChanged {
+                          sizeList[index] = Pair(it.width.toFloat(), it.height.toFloat())
                         },
-                    selectedContentColor = colorScheme.primary
-                ) {
-                    Text(
-                        text = str,
-                        style = TextStyle(
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 12.sp,
-                        ),
-                        modifier = Modifier
-                            .align(CenterHorizontally)
-                            .padding(horizontal = 32.dp, vertical = 16.dp)
-                    )
-                }
+                    selectedContentColor = colorScheme.primary) {
+                      Text(
+                          text = str,
+                          style =
+                              TextStyle(
+                                  fontWeight = FontWeight.Bold,
+                                  fontSize = 12.sp,
+                              ),
+                          modifier =
+                              Modifier.align(CenterHorizontally)
+                                  .padding(horizontal = 32.dp, vertical = 16.dp))
+                    }
+              }
             }
-        }
 
         DockedSearchBar(
             inputField = {
-                SearchBarDefaults.InputField(
-                    modifier = Modifier.testTag(HomeTestTags.SEARCH_BAR_INPUT),
-                    query = searchQuery,
-                    onQueryChange = {
-                        searchQuery = it
-                        searchViewModel.debouncedSearch(
-                            it,
-                            SearchViewModel.SearchType.EVENT
-                        )
-                    },
-                    onSearch = {},
-                    expanded = false,
-                    onExpandedChange = {},
-                    placeholder = {
-                        Text(text = context.getString(R.string.explore_search_placeholder))
-                    },
-                    trailingIcon = {
-                        if (searchState == SearchViewModel.Status.LOADING) {
-                            CircularProgressIndicator()
-                        } else {
-                            Icon(
-                                Icons.Default.Search,
-                                contentDescription =
-                                context.getString(R.string.home_content_description_search_icon)
-                            )
-                        }
-                    },
-                )
+              SearchBarDefaults.InputField(
+                  modifier = Modifier.testTag(HomeTestTags.SEARCH_BAR_INPUT),
+                  query = searchQuery,
+                  onQueryChange = {
+                    searchQuery = it
+                    searchViewModel.debouncedSearch(it, SearchViewModel.SearchType.EVENT)
+                  },
+                  onSearch = {},
+                  expanded = false,
+                  onExpandedChange = {},
+                  placeholder = {
+                    Text(text = context.getString(R.string.explore_search_placeholder))
+                  },
+                  trailingIcon = {
+                    if (searchState == SearchViewModel.Status.LOADING) {
+                      CircularProgressIndicator()
+                    } else {
+                      Icon(
+                          Icons.Default.Search,
+                          contentDescription =
+                              context.getString(R.string.home_content_description_search_icon))
+                    }
+                  },
+              )
             },
             expanded = false,
             onExpandedChange = {},
-            modifier = Modifier
-                .padding(horizontal = 16.dp)
-                .testTag(HomeTestTags.SEARCH_BAR)
-        ) {}
-
+            modifier = Modifier.padding(horizontal = 16.dp).testTag(HomeTestTags.SEARCH_BAR)) {}
 
         HorizontalPager(
-            state = pagerState, modifier = Modifier
-                .fillMaxWidth()
-        ) {
-            HomeContent(
-                navigationAction,
-                searchQuery,
-                searchState,
-                searchResults,
-                userViewModel,
-                eventViewModel,
-                paddingValues
-            )
-        }
-    }
+            state = pagerState, modifier = Modifier.fillMaxWidth().padding(top = 15.dp)) {
+              HomeContent(
+                  navigationAction,
+                  searchQuery,
+                  searchState,
+                  searchResults,
+                  userViewModel,
+                  eventViewModel,
+                  paddingValues)
+            }
+      }
 }

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -165,7 +165,7 @@ fun TopBar(
     eventViewModel: EventViewModel,
     paddingValues: PaddingValues
 ) {
-
+  val nbOfTabs = 2
   val context = LocalContext.current
 
   Column(
@@ -174,9 +174,12 @@ fun TopBar(
           Modifier.padding(paddingValues).padding(top = 20.dp, bottom = 50.dp).fillMaxSize()) {
         var searchQuery by remember { mutableStateOf("") }
 
-        val list = listOf("All", "Following")
+        val list =
+            listOf(
+                context.getString(R.string.home_tab_all),
+                context.getString(R.string.home_tab_following))
         val scope = rememberCoroutineScope()
-        val pagerState = rememberPagerState(initialPage = 0) { 2 }
+        val pagerState = rememberPagerState(initialPage = 0) { nbOfTabs }
 
         val sizeList = remember { mutableStateMapOf<Int, Pair<Float, Float>>() }
 
@@ -184,11 +187,14 @@ fun TopBar(
           derivedStateOf { pagerState.currentPageOffsetFraction + pagerState.currentPage.dp.value }
         }
         val colorScheme = MaterialTheme.colorScheme
+
+        // Tab Menu at the top of the page
         TabRow(
             selectedTabIndex = pagerState.currentPage,
             contentColor = Color(0xFF362C28),
             divider = {},
             indicator = {
+              // method that draws the indicator bar below the tab menu
               Box(
                   modifier =
                       Modifier.fillMaxSize().drawBehind {
@@ -210,12 +216,14 @@ fun TopBar(
                             strokeWidth = Stroke.DefaultMiter)
                       })
             }) {
+              val tabTestTags = listOf(HomeTestTags.TAB_ALL, HomeTestTags.TAB_FOLLOWING)
               list.forEachIndexed { index, str ->
                 Tab(
                     selected = index == pagerState.currentPage,
+                    // animate pager if click on tab
                     onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
                     modifier =
-                        Modifier.onSizeChanged {
+                        Modifier.testTag(tabTestTags[index]).onSizeChanged {
                           sizeList[index] = Pair(it.width.toFloat(), it.height.toFloat())
                         },
                     selectedContentColor = colorScheme.primary) {
@@ -239,6 +247,7 @@ fun TopBar(
                   modifier = Modifier.testTag(HomeTestTags.SEARCH_BAR_INPUT),
                   query = searchQuery,
                   onQueryChange = {
+                    // Search when query changes
                     searchQuery = it
                     searchViewModel.debouncedSearch(it, SearchViewModel.SearchType.EVENT)
                   },
@@ -263,7 +272,7 @@ fun TopBar(
             expanded = false,
             onExpandedChange = {},
             modifier = Modifier.padding(horizontal = 16.dp).testTag(HomeTestTags.SEARCH_BAR)) {}
-
+        // Pager Menu
         HorizontalPager(
             state = pagerState, modifier = Modifier.fillMaxWidth().padding(top = 15.dp)) {
               HomeContent(

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -162,6 +162,8 @@
     */
 
     <!-- Map Screen Strings -->
+    <string name="home_tab_all">Tout</string>
+    <string name="home_tab_following">Suivis</string>
     <string name="map_event_go_back_button">Retour</string>
     <string name="map_event_title">Carte d\'évènements</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,8 @@
     <!-- Home Screen Strings -->
     <string name="home_content_description_map_button">Map button</string>
     <string name="home_content_description_search_icon">Search icon</string>
+    <string name="home_tab_all" translatable="false">All</string>
+    <string name="home_tab_following">All</string>
 
     /**
     * package: map

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,8 +167,8 @@
     <!-- Home Screen Strings -->
     <string name="home_content_description_map_button">Map button</string>
     <string name="home_content_description_search_icon">Search icon</string>
-    <string name="home_tab_all" translatable="false">All</string>
-    <string name="home_tab_following" translatable="false">All</string>
+    <string name="home_tab_all">All</string>
+    <string name="home_tab_following">Following</string>
 
     /**
     * package: map

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,7 +168,7 @@
     <string name="home_content_description_map_button">Map button</string>
     <string name="home_content_description_search_icon">Search icon</string>
     <string name="home_tab_all" translatable="false">All</string>
-    <string name="home_tab_following">All</string>
+    <string name="home_tab_following" translatable="false">All</string>
 
     /**
     * package: map


### PR DESCRIPTION
The top bar menu was previously hardcoded a looked a bit "drafty" so I refactored it. It now uses the TabRow composable. I chose to use a custom indicator lambda so that the indicator moves along with the user's scroll instead of moving after the scroll.
This change took me way too much time but it looks cool ;)

I also cut the Home screen into smaller composables to make it more readable.