### PR TITLE
Refactor/repositories firestore operations

### DIFF
--- a/app/src/main/java/com/android/unio/model/firestore/FirestoreUtils.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/FirestoreUtils.kt
@@ -1,0 +1,23 @@
+package com.android.unio.model.firestore
+
+import android.util.Log
+import com.google.android.gms.tasks.Task
+
+/**
+ * Extension function that performs a Firestore operation and calls the appropriate callback based
+ * on the result.
+ */
+fun <T> Task<T>.performFirestoreOperation(onSuccess: (T) -> Unit, onFailure: (Exception) -> Unit) {
+  this.addOnSuccessListener { result ->
+        if (result == null) {
+          Log.e("FirestoreUtils", "Error performing Firestore operation: result is null")
+          onFailure(NullPointerException("Result is null"))
+          return@addOnSuccessListener
+        }
+        onSuccess(result)
+      }
+      .addOnFailureListener { exception ->
+        Log.e("FirestoreUtils", "Error performing Firestore operation", exception)
+        onFailure(exception)
+      }
+}

--- a/app/src/main/java/com/android/unio/model/image/ImageRepositoryFirebaseStorage.kt
+++ b/app/src/main/java/com/android/unio/model/image/ImageRepositoryFirebaseStorage.kt
@@ -1,5 +1,6 @@
 package com.android.unio.model.image
 
+import com.android.unio.model.firestore.performFirestoreOperation
 import com.google.firebase.storage.FirebaseStorage
 import java.io.InputStream
 import javax.inject.Inject
@@ -17,9 +18,8 @@ class ImageRepositoryFirebaseStorage @Inject constructor(storage: FirebaseStorag
   ) {
     val pathReference = storageRef.child(firebasePath)
 
-    pathReference.downloadUrl
-        .addOnSuccessListener { url -> onSuccess(url.toString()) }
-        .addOnFailureListener { e -> onFailure(e) }
+    pathReference.downloadUrl.performFirestoreOperation(
+        onSuccess = { url -> onSuccess(url.toString()) }, onFailure = { e -> onFailure(e) })
   }
 
   /** Uploads an image stream to Firebase Storage. Gives a downloadUrl to onSuccess. */
@@ -32,10 +32,8 @@ class ImageRepositoryFirebaseStorage @Inject constructor(storage: FirebaseStorag
     val path = storageRef.child(firebasePath)
     val uploadTask = path.putStream(imageStream)
 
-    uploadTask
-        .addOnSuccessListener {
-          getImageUrl(firebasePath, onSuccess = onSuccess, onFailure = onFailure)
-        }
-        .addOnFailureListener { exception -> onFailure(exception) }
+    uploadTask.performFirestoreOperation(
+        onSuccess = { getImageUrl(firebasePath, onSuccess = onSuccess, onFailure = onFailure) },
+        onFailure = { e -> onFailure(e) })
   }
 }

--- a/app/src/test/java/com/android/unio/model/association/AssociationRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/unio/model/association/AssociationRepositoryFirestoreTest.kt
@@ -134,7 +134,6 @@ class AssociationRepositoryFirestoreTest {
             "events" to association2.events.uids)
 
     `when`(queryDocumentSnapshot1.data).thenReturn(map1)
-    `when`(queryDocumentSnapshot2.data).thenReturn(map2)
 
     repository = AssociationRepositoryFirestore(db)
   }
@@ -173,6 +172,8 @@ class AssociationRepositoryFirestoreTest {
 
   @Test
   fun testGetAssociations() {
+    `when`(queryDocumentSnapshot2.data).thenReturn(map2)
+
     repository.getAssociations(
         onSuccess = { associations ->
           assertEquals(2, associations.size)
@@ -194,7 +195,7 @@ class AssociationRepositoryFirestoreTest {
   @Test
   fun testGetAssociationsWithMissingFields() {
     // Only set the ID for the second association, leaving the other fields as null
-    `when`(queryDocumentSnapshot2.id).thenReturn(association2.uid)
+    `when`(queryDocumentSnapshot2.data).thenReturn(mapOf("uid" to association2.uid))
 
     repository.getAssociations(
         onSuccess = { associations ->
@@ -244,6 +245,7 @@ class AssociationRepositoryFirestoreTest {
 
   @Test
   fun testGetAssociationsByCategory() {
+    `when`(queryDocumentSnapshot2.data).thenReturn(map2)
     `when`(associationCollectionReference.whereEqualTo(eq("category"), any()))
         .thenReturn(associationCollectionReference)
     repository.getAssociationsByCategory(

--- a/app/src/test/java/com/android/unio/model/event/EventRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/unio/model/event/EventRepositoryFirestoreTest.kt
@@ -223,6 +223,7 @@ class EventRepositoryFirestoreTest {
   @Test
   fun testAddEvent() {
     `when`(collectionReference.document(event1.uid)).thenReturn(documentReference)
+    `when`(voidTask.addOnSuccessListener(any())).thenReturn(voidTask)
     `when`(documentReference.set(any())).thenReturn(voidTask)
     repository.addEvent(event1, {}, { e -> throw e })
   }
@@ -242,6 +243,7 @@ class EventRepositoryFirestoreTest {
   @Test
   fun testDeleteEventById() {
     `when`(collectionReference.document(event1.uid)).thenReturn(documentReference)
+    `when`(voidTask.addOnSuccessListener(any())).thenReturn(voidTask)
     `when`(documentReference.delete()).thenReturn(voidTask)
     repository.deleteEventById(event1.uid, {}, { e -> throw e })
   }


### PR DESCRIPTION
## Description

This PR extracts the `performFirestoreOperation` function from a couple of repositories and consolidates it into a utility file, named `FirestoreUtils`. This function, which handles `Firestore` operations by invoking success and failure callbacks instead of the previous simple `onCompleteListener`, was either used in some repositories or not at all. The function was also transformed into an extension function, to simplify its usage.

## Motivation and context
The goal of this refactor is to improve code maintainability and readability, and to ensure callbacks are handled consistently.

### FirestoreUtils:
- Created this new utility file for Firestore utility functions.
- The `performFirestoreOperation` function has been transformed into an extension function on Task<T>
- Added error handling for cases where the result might be null, even though the `onSuccess` callback is invoked.

### Refactoring of Repositories:
- Updated `AssociationRepositoryFirestore`, `EventRepositoryFirestore`, `ImageRepositoryFirebaseStorage`, and `UserRepositoryFirestore` to use the `performFirestoreOperation` extension function.
- Removed the duplicate implementations of the `performFirestoreOperation` function from these repositories.

### Tests:
- Refactored tests in `AssociationRepositoryFirestoreTest` and `EventRepositoryFirestoreTest` to account for the change in the `performFirestoreOperation` implementation.

## How has this been tested?
The existing tests check that the repositories behave as expected.
I also tested manually, the app is fully functional with this refactor.