### PR TITLE
Minor end-to-end testing utilities

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -366,6 +366,17 @@ fun runCommand(command: String) {
                 konsole -e '$command'
                 """.trimIndent()
         ).start()
+    } else if (os.contains("mac")) {
+        ProcessBuilder(
+            "osascript",
+            "-e",
+            """
+                tell application "Terminal"
+                    do script "firebase emulators:start --import=./firebase/emulator-data"
+                    activate
+                end tell
+                """.trimIndent()
+        ).start()
     } else {
         throw GradleException("Unsupported operating system: $os")
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -361,9 +361,9 @@ fun runCommand(command: String) {
             "sh",
             "-c",
             """
-                x-terminal-emulator -e '${command}' ||
-                gnome-terminal -- bash -c '${command}; exec bash' ||
-                konsole -e '${command}'
+                x-terminal-emulator -e '$command' ||
+                gnome-terminal -- bash -c '$command; exec bash' ||
+                konsole -e '$command'
                 """.trimIndent()
         ).start()
     } else {
@@ -374,5 +374,11 @@ fun runCommand(command: String) {
 tasks.register("startFirebaseEmulators") {
     doLast {
         runCommand("firebase emulators:start --import=./firebase/emulator-data")
+    }
+}
+
+tasks.register("connectedCheckWithFirebaseEmulators") {
+    doLast {
+        runCommand("firebase emulators:exec --import=./firebase/emulator-data \"gradlew connectedCheck\"")
     }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -372,7 +372,7 @@ fun runCommand(command: String) {
             "-e",
             """
                 tell application "Terminal"
-                    do script "firebase emulators:start --import=./firebase/emulator-data"
+                    do script "$command"
                     activate
                 end tell
                 """.trimIndent()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -361,7 +361,7 @@ fun runCommand(command: String) {
             command // other commands
         }
         ProcessBuilder("cmd", "/c", "start", "cmd", "/k", adjustedCommand).start()
-    } else if (os.contains("nix") || os.contains("nux") || os.contains("bsd")) {
+    } else if (os.contains("nix") || os.contains("nux") || os.contains("bsd")) { //for linux, please run "chmod +x gradlew" in cd unio
         val adjustedCommand = if (command.contains("firebase emulators:exec")) {
             command.replace("./gradlew", "gradlew") // remove ./ for Linux
         } else {
@@ -376,7 +376,7 @@ fun runCommand(command: String) {
                 konsole -e '$adjustedCommand'
                 """.trimIndent()
         ).start()
-    } else if (os.contains("mac")) {
+    } else if (os.contains("mac")) { //for mac, please run "chmod +x gradlew" in cd unio
         ProcessBuilder(
             "osascript",
             "-e",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -352,24 +352,27 @@ configurations.forEach { configuration ->
   configuration.exclude("com.google.protobuf", "protobuf-lite")
 }
 
-tasks.register("startFirebaseEmulators") {
-    val command = "firebase emulators:start --import=./firebase/emulator-data"
-    doLast {
-        val os = System.getProperty("os.name").toLowerCase()
-        if (os.contains("win")) {
-            ProcessBuilder("cmd", "/c", "start", "cmd", "/k", command).start()
-        } else if (os.contains("nix") || os.contains("nux") || os.contains("bsd")) {
-            ProcessBuilder(
-                "sh",
-                "-c",
-                """
+fun runCommand(command: String) {
+    val os = System.getProperty("os.name").toLowerCase()
+    if (os.contains("win")) {
+        ProcessBuilder("cmd", "/c", "start", "cmd", "/k", command).start()
+    } else if (os.contains("nix") || os.contains("nux") || os.contains("bsd")) {
+        ProcessBuilder(
+            "sh",
+            "-c",
+            """
                 x-terminal-emulator -e '${command}' ||
                 gnome-terminal -- bash -c '${command}; exec bash' ||
                 konsole -e '${command}'
                 """.trimIndent()
-            ).start()
-        } else {
-            throw GradleException("Unsupported operating system: $os")
-        }
+        ).start()
+    } else {
+        throw GradleException("Unsupported operating system: $os")
+    }
+}
+
+tasks.register("startFirebaseEmulators") {
+    doLast {
+        runCommand("firebase emulators:start --import=./firebase/emulator-data")
     }
 }

--- a/app/src/androidTest/java/com/android/unio/end2end/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/android/unio/end2end/EndToEndTest.kt
@@ -73,8 +73,8 @@ open class EndToEndTest : FirebaseEmulatorFunctions {
 
   override fun useEmulators() {
     try {
-      Firebase.firestore.useEmulator(Firestore.HOST, 8080)
-      Firebase.auth.useEmulator(Auth.HOST, 9099)
+      Firebase.firestore.useEmulator(Firestore.HOST, Firestore.PORT)
+      Firebase.auth.useEmulator(Auth.HOST, Auth.PORT)
     } catch (e: IllegalStateException) {
       Log.e("EndToEndTest", e.message!!)
     }

--- a/app/src/androidTest/java/com/android/unio/end2end/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/android/unio/end2end/EndToEndTest.kt
@@ -62,19 +62,17 @@ open class EndToEndTest : FirebaseEmulatorFunctions {
               }
 
               override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
-                if (response.body == null) {
+                if (response.body == null || !response.body!!.string().contains("Ok")) {
                   throw Exception("Firebase Emulators are not running.")
                 }
-                val data = response.body!!.string()
-                assert(data.contains("Ok")) { "Firebase Emulators are not running." }
               }
             })
   }
 
   override fun useEmulators() {
     try {
-      Firebase.firestore.useEmulator(Firestore.HOST, Firestore.PORT)
-      Firebase.auth.useEmulator(Auth.HOST, Auth.PORT)
+      Firebase.firestore.useEmulator(HOST, Firestore.PORT)
+      Firebase.auth.useEmulator(HOST, Auth.PORT)
     } catch (e: IllegalStateException) {
       Log.e("EndToEndTest", e.message!!)
     }
@@ -96,19 +94,22 @@ open class EndToEndTest : FirebaseEmulatorFunctions {
     client.newCall(request).execute()
   }
 
+  companion object {
+    const val HOST = "10.0.2.2"
+  }
+
   /* Constant URLs used by the local emulator */
   object Firestore {
-    const val HOST = "10.0.2.2"
     const val PORT = 8080
     const val ROOT = "http://$HOST:$PORT"
-    const val SHORT_ROOT = "$HOST:$PORT"
+
     const val DATABASE_URL = "$ROOT/emulator/v1/projects/unio-1b8ee/databases/(default)/documents"
   }
 
   object Auth {
-    const val HOST = "10.0.2.2"
     const val PORT = 9099
     const val ROOT = "http://$HOST:$PORT"
+
     const val OOB_URL = "$ROOT/emulator/v1/projects/unio-1b8ee/oobCodes"
     const val ACCOUNTS_URL = "$ROOT/emulator/v1/projects/unio-1b8ee/accounts"
   }


### PR DESCRIPTION
This pull request adds some minor utilities that aim to help running end-to-end tests locally. These are only helpful tools for developers and are not meant to be included in the CI. There are two Gradle commands that have been added:
- `startFirebaseEmulators` Simply starts the Firebase emulators as defined by `firebase.json` and imports the data stored in `firebase/emulator-data`.
- `connectedCheckWithFirebaseEmulators` Same as above, but also runs `connectedCheck` when the emulators are launched and closes the emulators after the tests are executed.

Note that I have only tested these Gradle commands on Windows as I only have a Windows PC. Please let me know if they do not work on Linux or MacOS.

This pull request also cleans up a little the `EndToEndTest` class, with better error handling and constant extraction.