### PR TITLE
Link EventDetails to the Map Screen

### DIFF
--- a/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
@@ -240,7 +240,8 @@ class ScreenDisplayingTest {
       EventScreen(
           navigationAction = navigationAction,
           eventViewModel = eventViewModel,
-          userViewModel = userViewModel)
+          userViewModel = userViewModel,
+          mapViewModel = mapViewModel)
     }
     composeTestRule.onNodeWithTag(EventDetailsTestTags.SCREEN).assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/android/unio/ui/authentication/AccountDetailsTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/authentication/AccountDetailsTest.kt
@@ -163,7 +163,7 @@ class AccountDetailsTest {
         .performScrollTo()
         .assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag(AccountDetailsTestTags.SOCIALS_CHIP + "Instagram")
+        .onNodeWithTag(AccountDetailsTestTags.SOCIALS_CHIP + "Instagram", true)
         .performScrollTo()
         .assertIsDisplayed()
   }

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -47,8 +47,8 @@ import com.android.unio.ui.theme.AppTheme
 import com.android.unio.ui.user.UserProfileScreen
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.HiltAndroidApp
-import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import javax.inject.Inject
+import me.zhanghai.compose.preference.ProvidePreferenceLocals
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -116,7 +116,7 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
             navigationAction = navigationActions,
             eventViewModel = eventViewModel,
             userViewModel = userViewModel,
-          mapViewModel)
+            mapViewModel)
       }
       composable(Screen.MAP) {
         MapScreen(navigationActions, eventViewModel, userViewModel, mapViewModel)

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -47,8 +47,8 @@ import com.android.unio.ui.theme.AppTheme
 import com.android.unio.ui.user.UserProfileScreen
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.HiltAndroidApp
-import javax.inject.Inject
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -115,7 +115,8 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
         EventScreen(
             navigationAction = navigationActions,
             eventViewModel = eventViewModel,
-            userViewModel = userViewModel)
+            userViewModel = userViewModel,
+          mapViewModel)
       }
       composable(Screen.MAP) {
         MapScreen(navigationActions, eventViewModel, userViewModel, mapViewModel)

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -116,7 +116,7 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
             navigationAction = navigationActions,
             eventViewModel = eventViewModel,
             userViewModel = userViewModel,
-            mapViewModel)
+            mapViewModel = mapViewModel)
       }
       composable(Screen.MAP) {
         MapScreen(navigationActions, eventViewModel, userViewModel, mapViewModel)

--- a/app/src/main/java/com/android/unio/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/map/MapViewModel.kt
@@ -8,10 +8,10 @@ import androidx.lifecycle.ViewModel
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.maps.model.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
 
 @HiltViewModel
 class MapViewModel
@@ -21,6 +21,9 @@ constructor(private val fusedLocationClient: FusedLocationProviderClient) : View
   /** State flow that holds the user's location. */
   private val _userLocation = MutableStateFlow<LatLng?>(null)
   val userLocation: StateFlow<LatLng?> = _userLocation.asStateFlow()
+
+  private val _centerLocation = MutableStateFlow<LatLng?>(null)
+  val centerLocation: StateFlow<LatLng?> = _centerLocation.asStateFlow()
 
   /** Fetches the user's location and updates the [_userLocation] state flow. */
   fun fetchUserLocation(context: Context) {

--- a/app/src/main/java/com/android/unio/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/map/MapViewModel.kt
@@ -8,10 +8,10 @@ import androidx.lifecycle.ViewModel
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.maps.model.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import javax.inject.Inject
 
 @HiltViewModel
 class MapViewModel
@@ -27,6 +27,7 @@ constructor(private val fusedLocationClient: FusedLocationProviderClient) : View
 
   /**
    * Sets a center location for the map given a location
+   *
    * @param location the location to center the map on.
    */
   fun setCenterLocation(location: Location?) {
@@ -35,7 +36,6 @@ constructor(private val fusedLocationClient: FusedLocationProviderClient) : View
     } else {
       _centerLocation.value = null
     }
-
   }
 
   /** Fetches the user's location and updates the [_userLocation] state flow. */

--- a/app/src/main/java/com/android/unio/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/map/MapViewModel.kt
@@ -25,6 +25,14 @@ constructor(private val fusedLocationClient: FusedLocationProviderClient) : View
   private val _centerLocation = MutableStateFlow<LatLng?>(null)
   val centerLocation: StateFlow<LatLng?> = _centerLocation.asStateFlow()
 
+  /**
+   * Sets a center location for the map given a location
+   * @param location the location to center the map on.
+   */
+  fun setCenterLocation(location: Location) {
+    _centerLocation.value = LatLng(location.latitude, location.longitude)
+  }
+
   /** Fetches the user's location and updates the [_userLocation] state flow. */
   fun fetchUserLocation(context: Context) {
     if (hasLocationPermissions(context)) {

--- a/app/src/main/java/com/android/unio/model/map/MapViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/map/MapViewModel.kt
@@ -29,8 +29,13 @@ constructor(private val fusedLocationClient: FusedLocationProviderClient) : View
    * Sets a center location for the map given a location
    * @param location the location to center the map on.
    */
-  fun setCenterLocation(location: Location) {
-    _centerLocation.value = LatLng(location.latitude, location.longitude)
+  fun setCenterLocation(location: Location?) {
+    if (location != null) {
+      _centerLocation.value = LatLng(location.latitude, location.longitude)
+    } else {
+      _centerLocation.value = null
+    }
+
   }
 
   /** Fetches the user's location and updates the [_userLocation] state flow. */

--- a/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
@@ -64,15 +64,17 @@ import com.android.unio.model.association.Association
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventUtils.formatTimestamp
 import com.android.unio.model.event.EventViewModel
+import com.android.unio.model.map.MapViewModel
 import com.android.unio.model.strings.test_tags.EventDetailsTestTags
 import com.android.unio.model.user.UserViewModel
 import com.android.unio.ui.image.AsyncImageWrapper
 import com.android.unio.ui.navigation.NavigationAction
+import com.android.unio.ui.navigation.Screen
 import com.android.unio.ui.theme.AppTypography
-import java.text.SimpleDateFormat
-import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 private const val DEBUG_MESSAGE = "<DEBUG> Not implemented yet"
 private val DEBUG_LAMBDA: () -> Unit = {
@@ -91,7 +93,8 @@ private var scope: CoroutineScope? = null
 fun EventScreen(
     navigationAction: NavigationAction,
     eventViewModel: EventViewModel,
-    userViewModel: UserViewModel
+    userViewModel: UserViewModel,
+    mapViewModel: MapViewModel,
 ) {
 
   val event by eventViewModel.selectedEvent.collectAsState()
@@ -116,13 +119,14 @@ fun EventScreen(
     userViewModel.updateUserDebounced(user!!)
   }
 
-  EventScreenScaffold(navigationAction, event!!, associations, isSaved, onClickSaveButton)
+  EventScreenScaffold(navigationAction, mapViewModel, event!!, associations, isSaved, onClickSaveButton)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EventScreenScaffold(
     navigationAction: NavigationAction,
+    mapViewModel: MapViewModel,
     event: Event,
     associations: List<Association>,
     isSaved: Boolean,
@@ -184,11 +188,11 @@ fun EventScreenScaffold(
                   }
             })
       },
-      content = { padding -> EventScreenContent(event, associations, padding) })
+      content = { padding -> EventScreenContent(navigationAction, mapViewModel,event, associations, padding) })
 }
 
 @Composable
-fun EventScreenContent(event: Event, associations: List<Association>, padding: PaddingValues) {
+fun EventScreenContent(navigationAction: NavigationAction, mapViewModel: MapViewModel, event: Event, associations: List<Association>, padding: PaddingValues) {
   val context = LocalContext.current
   Column(
       modifier =
@@ -204,14 +208,14 @@ fun EventScreenContent(event: Event, associations: List<Association>, padding: P
               contentScale = ContentScale.Crop)
         }
 
-        EventInformationCard(event, associations, context)
+        EventInformationCard(mapViewModel,event, associations, context)
 
-        EventDetailsBody(event, context)
+        EventDetailsBody(navigationAction,mapViewModel, event, context)
       }
 }
 
 @Composable
-fun EventInformationCard(event: Event, associations: List<Association>, context: Context) {
+fun EventInformationCard(mapViewModel: MapViewModel, event: Event, associations: List<Association>, context: Context) {
   Column(
       modifier =
           Modifier.testTag(EventDetailsTestTags.DETAILS_INFORMATION_CARD)
@@ -269,7 +273,7 @@ fun EventInformationCard(event: Event, associations: List<Association>, context:
 }
 
 @Composable
-fun EventDetailsBody(event: Event, context: Context) {
+fun EventDetailsBody(navigationAction: NavigationAction, mapViewModel: MapViewModel, event: Event,context: Context) {
   Column(
       modifier = Modifier.testTag(EventDetailsTestTags.DETAILS_BODY).padding(9.dp).fillMaxHeight(),
       verticalArrangement = Arrangement.spacedBy(30.dp)) {
@@ -305,7 +309,10 @@ fun EventDetailsBody(event: Event, context: Context) {
             modifier = Modifier.fillMaxSize().padding(top = 30.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp)) {
               OutlinedButton(
-                  onClick = DEBUG_LAMBDA,
+                  onClick = {
+                      mapViewModel.centerLocation
+                      navigationAction.navigateTo(Screen.MAP)
+                  },
                   modifier =
                       Modifier.testTag(EventDetailsTestTags.MAP_BUTTON)
                           .align(Alignment.CenterHorizontally)

--- a/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
@@ -71,10 +71,10 @@ import com.android.unio.ui.image.AsyncImageWrapper
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.navigation.Screen
 import com.android.unio.ui.theme.AppTypography
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Locale
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 private const val DEBUG_MESSAGE = "<DEBUG> Not implemented yet"
 private val DEBUG_LAMBDA: () -> Unit = {
@@ -119,7 +119,8 @@ fun EventScreen(
     userViewModel.updateUserDebounced(user!!)
   }
 
-  EventScreenScaffold(navigationAction, mapViewModel, event!!, associations, isSaved, onClickSaveButton)
+  EventScreenScaffold(
+      navigationAction, mapViewModel, event!!, associations, isSaved, onClickSaveButton)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -188,11 +189,19 @@ fun EventScreenScaffold(
                   }
             })
       },
-      content = { padding -> EventScreenContent(navigationAction, mapViewModel,event, associations, padding) })
+      content = { padding ->
+        EventScreenContent(navigationAction, mapViewModel, event, associations, padding)
+      })
 }
 
 @Composable
-fun EventScreenContent(navigationAction: NavigationAction, mapViewModel: MapViewModel, event: Event, associations: List<Association>, padding: PaddingValues) {
+fun EventScreenContent(
+    navigationAction: NavigationAction,
+    mapViewModel: MapViewModel,
+    event: Event,
+    associations: List<Association>,
+    padding: PaddingValues
+) {
   val context = LocalContext.current
   Column(
       modifier =
@@ -208,14 +217,19 @@ fun EventScreenContent(navigationAction: NavigationAction, mapViewModel: MapView
               contentScale = ContentScale.Crop)
         }
 
-        EventInformationCard(mapViewModel,event, associations, context)
+        EventInformationCard(mapViewModel, event, associations, context)
 
-        EventDetailsBody(navigationAction,mapViewModel, event, context)
+        EventDetailsBody(navigationAction, mapViewModel, event, context)
       }
 }
 
 @Composable
-fun EventInformationCard(mapViewModel: MapViewModel, event: Event, associations: List<Association>, context: Context) {
+fun EventInformationCard(
+    mapViewModel: MapViewModel,
+    event: Event,
+    associations: List<Association>,
+    context: Context
+) {
   Column(
       modifier =
           Modifier.testTag(EventDetailsTestTags.DETAILS_INFORMATION_CARD)
@@ -273,7 +287,12 @@ fun EventInformationCard(mapViewModel: MapViewModel, event: Event, associations:
 }
 
 @Composable
-fun EventDetailsBody(navigationAction: NavigationAction, mapViewModel: MapViewModel, event: Event,context: Context) {
+fun EventDetailsBody(
+    navigationAction: NavigationAction,
+    mapViewModel: MapViewModel,
+    event: Event,
+    context: Context
+) {
   Column(
       modifier = Modifier.testTag(EventDetailsTestTags.DETAILS_BODY).padding(9.dp).fillMaxHeight(),
       verticalArrangement = Arrangement.spacedBy(30.dp)) {
@@ -310,8 +329,8 @@ fun EventDetailsBody(navigationAction: NavigationAction, mapViewModel: MapViewMo
             verticalArrangement = Arrangement.spacedBy(20.dp)) {
               OutlinedButton(
                   onClick = {
-                      mapViewModel.setCenterLocation(event.location)
-                      navigationAction.navigateTo(Screen.MAP)
+                    mapViewModel.setCenterLocation(event.location)
+                    navigationAction.navigateTo(Screen.MAP)
                   },
                   modifier =
                       Modifier.testTag(EventDetailsTestTags.MAP_BUTTON)

--- a/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
@@ -217,19 +217,14 @@ fun EventScreenContent(
               contentScale = ContentScale.Crop)
         }
 
-        EventInformationCard(mapViewModel, event, associations, context)
+        EventInformationCard(event, associations, context)
 
         EventDetailsBody(navigationAction, mapViewModel, event, context)
       }
 }
 
 @Composable
-fun EventInformationCard(
-    mapViewModel: MapViewModel,
-    event: Event,
-    associations: List<Association>,
-    context: Context
-) {
+fun EventInformationCard(event: Event, associations: List<Association>, context: Context) {
   Column(
       modifier =
           Modifier.testTag(EventDetailsTestTags.DETAILS_INFORMATION_CARD)

--- a/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
@@ -310,7 +310,7 @@ fun EventDetailsBody(navigationAction: NavigationAction, mapViewModel: MapViewMo
             verticalArrangement = Arrangement.spacedBy(20.dp)) {
               OutlinedButton(
                   onClick = {
-                      mapViewModel.centerLocation
+                      mapViewModel.setCenterLocation(event.location)
                       navigationAction.navigateTo(Screen.MAP)
                   },
                   modifier =

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -66,7 +66,7 @@ fun HomeScreen(
     navigationAction: NavigationAction,
     eventViewModel: EventViewModel,
     userViewModel: UserViewModel,
-    searchViewModel: SearchViewModel
+    searchViewModel: SearchViewModel,
 ) {
   val context = LocalContext.current
 

--- a/app/src/main/java/com/android/unio/ui/map/Map.kt
+++ b/app/src/main/java/com/android/unio/ui/map/Map.kt
@@ -73,7 +73,7 @@ fun MapScreen(
   val cameraPositionState = rememberCameraPositionState()
   val centerLocation by mapViewModel.centerLocation.collectAsState()
   val userLocation by mapViewModel.userLocation.collectAsState()
-  var initialCentered by remember { mutableStateOf(false) }
+  var initialCentered = false
   var isMyLocationEnabled by remember { mutableStateOf(false) }
   var showApproximateCircle by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/android/unio/ui/map/Map.kt
+++ b/app/src/main/java/com/android/unio/ui/map/Map.kt
@@ -133,16 +133,23 @@ fun MapScreen(
                 requestPermissions()
             }
         }
+        // this line seems to not do anything !
         cameraPositionState.position =
-            CameraPosition.fromLatLngZoom(centerLocation ?: EPFL_COORDINATES, INITIAL_ZOOM_LEVEL)
+          CameraPosition.fromLatLngZoom(userLocation ?: EPFL_COORDINATES, INITIAL_ZOOM_LEVEL)
     }
 
     // Center map on the center location initially if available
-    LaunchedEffect(centerLocation) {
-        if (userLocation != null && !initialCentered) {
+    LaunchedEffect(userLocation) {
+        if (userLocation != null && centerLocation == null) {
+            cameraPositionState.position =
+                CameraPosition.fromLatLngZoom(userLocation!!, INITIAL_ZOOM_LEVEL)
+            initialCentered = true
+        } else if (centerLocation != null) {
             cameraPositionState.position =
                 CameraPosition.fromLatLngZoom(centerLocation!!, INITIAL_ZOOM_LEVEL)
-            initialCentered = true
+        } else {
+            cameraPositionState.position =
+                CameraPosition.fromLatLngZoom(EPFL_COORDINATES, INITIAL_ZOOM_LEVEL)
         }
     }
 
@@ -158,7 +165,9 @@ fun MapScreen(
                 },
                 navigationIcon = {
                     IconButton(
-                        onClick = { navigationAction.goBack() },
+                        onClick = {
+                            mapViewModel.setCenterLocation(null)
+                            navigationAction.goBack() },
                         modifier = Modifier.testTag(MapTestTags.GO_BACK_BUTTON)
                     ) {
                         Icon(

--- a/app/src/main/java/com/android/unio/ui/map/Map.kt
+++ b/app/src/main/java/com/android/unio/ui/map/Map.kt
@@ -67,7 +67,7 @@ fun MapScreen(
     navigationAction: NavigationAction,
     eventViewModel: EventViewModel,
     userViewModel: UserViewModel,
-    mapViewModel: MapViewModel
+    mapViewModel: MapViewModel,
 ) {
   val context = LocalContext.current
   val cameraPositionState = rememberCameraPositionState()

--- a/app/src/main/java/com/android/unio/ui/map/Map.kt
+++ b/app/src/main/java/com/android/unio/ui/map/Map.kt
@@ -126,16 +126,19 @@ fun MapScreen(
 
   // Center map on the center location initially if available
   LaunchedEffect(userLocation) {
-    if (userLocation != null && centerLocation == null) {
-      cameraPositionState.position =
-          CameraPosition.fromLatLngZoom(userLocation!!, INITIAL_ZOOM_LEVEL)
+    if (!initialCentered) {
+
+      if (centerLocation != null) {
+        cameraPositionState.position =
+            CameraPosition.fromLatLngZoom(centerLocation!!, INITIAL_ZOOM_LEVEL)
+      } else if (userLocation != null) {
+        cameraPositionState.position =
+            CameraPosition.fromLatLngZoom(userLocation!!, INITIAL_ZOOM_LEVEL)
+      } else {
+        cameraPositionState.position =
+            CameraPosition.fromLatLngZoom(EPFL_COORDINATES, INITIAL_ZOOM_LEVEL)
+      }
       initialCentered = true
-    } else if (centerLocation != null) {
-      cameraPositionState.position =
-          CameraPosition.fromLatLngZoom(centerLocation!!, INITIAL_ZOOM_LEVEL)
-    } else {
-      cameraPositionState.position =
-          CameraPosition.fromLatLngZoom(EPFL_COORDINATES, INITIAL_ZOOM_LEVEL)
     }
   }
 

--- a/app/src/main/java/com/android/unio/ui/map/Map.kt
+++ b/app/src/main/java/com/android/unio/ui/map/Map.kt
@@ -69,131 +69,112 @@ fun MapScreen(
     userViewModel: UserViewModel,
     mapViewModel: MapViewModel,
 ) {
-    val context = LocalContext.current
-    val cameraPositionState = rememberCameraPositionState()
-    val centerLocation by mapViewModel.centerLocation.collectAsState()
-    val userLocation by mapViewModel.userLocation.collectAsState()
-    var initialCentered by remember { mutableStateOf(false) }
-    var isMyLocationEnabled by remember { mutableStateOf(false) }
-    var showApproximateCircle by remember { mutableStateOf(false) }
+  val context = LocalContext.current
+  val cameraPositionState = rememberCameraPositionState()
+  val centerLocation by mapViewModel.centerLocation.collectAsState()
+  val userLocation by mapViewModel.userLocation.collectAsState()
+  var initialCentered by remember { mutableStateOf(false) }
+  var isMyLocationEnabled by remember { mutableStateOf(false) }
+  var showApproximateCircle by remember { mutableStateOf(false) }
 
-    val permissionLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-            when {
-                permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) -> {
-                    mapViewModel.fetchUserLocation(context)
-                    isMyLocationEnabled = true
-                    showApproximateCircle = false
-                }
-
-                permissions.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false) -> {
-                    mapViewModel.fetchUserLocation(context)
-                    isMyLocationEnabled = false
-                    showApproximateCircle = true
-                }
-
-                else -> {
-                    Log.e("MapScreen", "Location permission is not granted.")
-                }
-            }
+  val permissionLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+          permissions ->
+        when {
+          permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) -> {
+            mapViewModel.fetchUserLocation(context)
+            isMyLocationEnabled = true
+            showApproximateCircle = false
+          }
+          permissions.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false) -> {
+            mapViewModel.fetchUserLocation(context)
+            isMyLocationEnabled = false
+            showApproximateCircle = true
+          }
+          else -> {
+            Log.e("MapScreen", "Location permission is not granted.")
+          }
         }
+      }
 
-    /** Request location permissions. */
-    fun requestPermissions() {
-        permissionLauncher.launch(
-            arrayOf(
-                Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
-            )
-        )
+  /** Request location permissions. */
+  fun requestPermissions() {
+    permissionLauncher.launch(
+        arrayOf(
+            Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
+  }
+
+  // Check what permissions are already granted
+  LaunchedEffect(Unit) {
+    when (PackageManager.PERMISSION_GRANTED) {
+      ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) -> {
+        isMyLocationEnabled = true
+        showApproximateCircle = false
+        mapViewModel.fetchUserLocation(context)
+      }
+      ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) -> {
+        isMyLocationEnabled = false
+        showApproximateCircle = true
+        requestPermissions()
+        mapViewModel.fetchUserLocation(context)
+      }
+      else -> {
+        requestPermissions()
+      }
     }
+  }
 
-    // Check what permissions are already granted
-    LaunchedEffect(Unit) {
-        when (PackageManager.PERMISSION_GRANTED) {
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.ACCESS_FINE_LOCATION
-            ) -> {
-                isMyLocationEnabled = true
-                showApproximateCircle = false
-                mapViewModel.fetchUserLocation(context)
-            }
-
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.ACCESS_COARSE_LOCATION
-            ) -> {
-                isMyLocationEnabled = false
-                showApproximateCircle = true
-                requestPermissions()
-                mapViewModel.fetchUserLocation(context)
-            }
-
-            else -> {
-                requestPermissions()
-            }
-        }
-        // this line seems to not do anything !
-        cameraPositionState.position =
-          CameraPosition.fromLatLngZoom(userLocation ?: EPFL_COORDINATES, INITIAL_ZOOM_LEVEL)
+  // Center map on the center location initially if available
+  LaunchedEffect(userLocation) {
+    if (userLocation != null && centerLocation == null) {
+      cameraPositionState.position =
+          CameraPosition.fromLatLngZoom(userLocation!!, INITIAL_ZOOM_LEVEL)
+      initialCentered = true
+    } else if (centerLocation != null) {
+      cameraPositionState.position =
+          CameraPosition.fromLatLngZoom(centerLocation!!, INITIAL_ZOOM_LEVEL)
+    } else {
+      cameraPositionState.position =
+          CameraPosition.fromLatLngZoom(EPFL_COORDINATES, INITIAL_ZOOM_LEVEL)
     }
+  }
 
-    // Center map on the center location initially if available
-    LaunchedEffect(userLocation) {
-        if (userLocation != null && centerLocation == null) {
-            cameraPositionState.position =
-                CameraPosition.fromLatLngZoom(userLocation!!, INITIAL_ZOOM_LEVEL)
-            initialCentered = true
-        } else if (centerLocation != null) {
-            cameraPositionState.position =
-                CameraPosition.fromLatLngZoom(centerLocation!!, INITIAL_ZOOM_LEVEL)
-        } else {
-            cameraPositionState.position =
-                CameraPosition.fromLatLngZoom(EPFL_COORDINATES, INITIAL_ZOOM_LEVEL)
-        }
-    }
-
-    Scaffold(
-        modifier = Modifier.testTag(MapTestTags.SCREEN),
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        context.getString(R.string.map_event_title),
-                        modifier = Modifier.testTag(MapTestTags.TITLE)
-                    )
-                },
-                navigationIcon = {
-                    IconButton(
-                        onClick = {
-                            mapViewModel.setCenterLocation(null)
-                            navigationAction.goBack() },
-                        modifier = Modifier.testTag(MapTestTags.GO_BACK_BUTTON)
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
-                            contentDescription = context.getString(R.string.map_event_go_back_button)
-                        )
-                    }
-                })
-        },
-        floatingActionButton = {
-            FloatingActionButton(
-                modifier = Modifier
-                    .padding(bottom = 80.dp)
-                    .testTag(MapTestTags.CENTER_ON_USER_FAB),
-                onClick = {
-                    userLocation?.let {
-                        cameraPositionState.position = CameraPosition.fromLatLngZoom(it, 15f)
-                    }
-                }) {
-                Icon(
-                    Icons.Default.MyLocation,
-                    contentDescription =
-                    context.getString(R.string.map_content_description_center_on_user)
-                )
+  Scaffold(
+      modifier = Modifier.testTag(MapTestTags.SCREEN),
+      topBar = {
+        TopAppBar(
+            title = {
+              Text(
+                  context.getString(R.string.map_event_title),
+                  modifier = Modifier.testTag(MapTestTags.TITLE))
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = {
+                    mapViewModel.setCenterLocation(null)
+                    navigationAction.goBack()
+                  },
+                  modifier = Modifier.testTag(MapTestTags.GO_BACK_BUTTON)) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = context.getString(R.string.map_event_go_back_button))
+                  }
+            })
+      },
+      floatingActionButton = {
+        FloatingActionButton(
+            modifier = Modifier.padding(bottom = 80.dp).testTag(MapTestTags.CENTER_ON_USER_FAB),
+            onClick = {
+              userLocation?.let {
+                cameraPositionState.position = CameraPosition.fromLatLngZoom(it, 15f)
+              }
+            }) {
+              Icon(
+                  Icons.Default.MyLocation,
+                  contentDescription =
+                      context.getString(R.string.map_content_description_center_on_user))
             }
-        }) { pd ->
+      }) { pd ->
         EventMap(
             pd,
             eventViewModel,
@@ -201,9 +182,8 @@ fun MapScreen(
             cameraPositionState,
             isMyLocationEnabled,
             showApproximateCircle,
-            userLocation
-        )
-    }
+            userLocation)
+      }
 }
 
 @Composable
@@ -216,37 +196,33 @@ fun EventMap(
     showApproximateCircle: Boolean,
     userLocation: LatLng?
 ) {
-    val events = eventViewModel.events.collectAsState()
+  val events = eventViewModel.events.collectAsState()
 
-    val user by userViewModel.user.collectAsState()
-    val savedEvents by user!!.savedEvents.list.collectAsState()
-    LaunchedEffect(user) { user?.savedEvents?.requestAll() }
+  val user by userViewModel.user.collectAsState()
+  val savedEvents by user!!.savedEvents.list.collectAsState()
+  LaunchedEffect(user) { user?.savedEvents?.requestAll() }
 
-    GoogleMap(
-        modifier = Modifier
-            .padding(pd)
-            .testTag(MapTestTags.GOOGLE_MAPS),
-        cameraPositionState = cameraPositionState,
-        properties = MapProperties(isMyLocationEnabled = isMyLocatonEnabled),
-        uiSettings = MapUiSettings(myLocationButtonEnabled = false)
-    ) {
+  GoogleMap(
+      modifier = Modifier.padding(pd).testTag(MapTestTags.GOOGLE_MAPS),
+      cameraPositionState = cameraPositionState,
+      properties = MapProperties(isMyLocationEnabled = isMyLocatonEnabled),
+      uiSettings = MapUiSettings(myLocationButtonEnabled = false)) {
         // Display the user's approximate location if only coarse location is available
         if (showApproximateCircle && userLocation != null) {
-            Circle(
-                center = userLocation,
-                radius = APPROXIMATE_CIRCLE_RADIUS,
-                fillColor = mapUserLocationCircleFiller,
-                strokeColor = mapUserLocationCircleStroke,
-                strokeWidth = APPROXIMATE_CIRCLE_OUTLINE_WIDTH,
-                tag = MapTestTags.LOCATION_APPROXIMATE_CIRCLE
-            )
+          Circle(
+              center = userLocation,
+              radius = APPROXIMATE_CIRCLE_RADIUS,
+              fillColor = mapUserLocationCircleFiller,
+              strokeColor = mapUserLocationCircleStroke,
+              strokeWidth = APPROXIMATE_CIRCLE_OUTLINE_WIDTH,
+              tag = MapTestTags.LOCATION_APPROXIMATE_CIRCLE)
         }
 
         // Display saved events
         savedEvents.forEach { event ->
-            if (event.date.toDate() > Calendar.getInstance().time) {
-                DisplayEventMarker(event, R.drawable.favorite_pinpoint)
-            }
+          if (event.date.toDate() > Calendar.getInstance().time) {
+            DisplayEventMarker(event, R.drawable.favorite_pinpoint)
+          }
         }
 
         // Display all events (should refactor to the ones that are soon to happen when more events
@@ -254,11 +230,11 @@ fun EventMap(
         events.value
             .filterNot { event -> savedEvents.any { it.uid == event.uid } }
             .forEach { event ->
-                if (event.date.toDate() > Calendar.getInstance().time) {
-                    DisplayEventMarker(event, null)
-                }
+              if (event.date.toDate() > Calendar.getInstance().time) {
+                DisplayEventMarker(event, null)
+              }
             }
-    }
+      }
 }
 
 /**
@@ -270,26 +246,24 @@ fun EventMap(
  */
 @Composable
 fun DisplayEventMarker(event: Event, customIconResId: Int?) {
-    val timer = timeUntilEvent(event.date)
-    event.location.let { location ->
-        val pinPointIcon =
-            if (customIconResId != null) {
-                val bitmap =
-                    BitmapFactory.decodeResource(LocalContext.current.resources, customIconResId)
-                val scaledBitmap = Bitmap.createScaledBitmap(bitmap, 96, 96, false)
-                BitmapDescriptorFactory.fromBitmap(scaledBitmap)
-            } else {
-                BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE)
-            }
+  val timer = timeUntilEvent(event.date)
+  event.location.let { location ->
+    val pinPointIcon =
+        if (customIconResId != null) {
+          val bitmap = BitmapFactory.decodeResource(LocalContext.current.resources, customIconResId)
+          val scaledBitmap = Bitmap.createScaledBitmap(bitmap, 96, 96, false)
+          BitmapDescriptorFactory.fromBitmap(scaledBitmap)
+        } else {
+          BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE)
+        }
 
-        Marker(
-            contentDescription = "Event: ${event.title}",
-            state = MarkerState(position = LatLng(location.latitude, location.longitude)),
-            title = event.title,
-            snippet = "$timer - ${event.description}",
-            icon = pinPointIcon
-        )
-    }
+    Marker(
+        contentDescription = "Event: ${event.title}",
+        state = MarkerState(position = LatLng(location.latitude, location.longitude)),
+        title = event.title,
+        snippet = "$timer - ${event.description}",
+        icon = pinPointIcon)
+  }
 }
 
 /**
@@ -299,12 +273,12 @@ fun DisplayEventMarker(event: Event, customIconResId: Int?) {
  * @return a string giving information about the time until the event occurs
  */
 fun timeUntilEvent(eventTimestamp: Timestamp): String {
-    val currentTime = Timestamp.now()
-    val timeDifference = eventTimestamp.seconds - currentTime.seconds
+  val currentTime = Timestamp.now()
+  val timeDifference = eventTimestamp.seconds - currentTime.seconds
 
-    if (timeDifference < 0) return MapStrings.EVENT_ALREADY_OCCURED
+  if (timeDifference < 0) return MapStrings.EVENT_ALREADY_OCCURED
 
-    val days = TimeUnit.SECONDS.toDays(timeDifference)
-    val hours = TimeUnit.SECONDS.toHours(timeDifference) % 24
-    return if (days > 0) "In $days days, $hours hours" else "In $hours hours"
+  val days = TimeUnit.SECONDS.toDays(timeDifference)
+  val hours = TimeUnit.SECONDS.toHours(timeDifference) % 24
+  return if (days > 0) "In $days days, $hours hours" else "In $hours hours"
 }

--- a/app/src/test/java/com/android/unio/model/map/MapViewModelTest.kt
+++ b/app/src/test/java/com/android/unio/model/map/MapViewModelTest.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Looper
 import androidx.core.content.ContextCompat
+import com.android.unio.mocks.map.MockLocation
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.tasks.OnFailureListener
@@ -102,5 +103,13 @@ class MapViewModelTest {
 
     val result = mapViewModel.userLocation.first()
     assertEquals(null, result)
+  }
+
+  @Test
+  fun testSetCenterLocation() {
+    val location = MockLocation.createMockLocation(latitude = 10.0, longitude = 34.7)
+    mapViewModel.setCenterLocation(location)
+    assertEquals(location.latitude,mapViewModel.centerLocation.value?.latitude)
+    assertEquals(location.longitude,mapViewModel.centerLocation.value?.longitude)
   }
 }

--- a/app/src/test/java/com/android/unio/model/map/MapViewModelTest.kt
+++ b/app/src/test/java/com/android/unio/model/map/MapViewModelTest.kt
@@ -109,7 +109,7 @@ class MapViewModelTest {
   fun testSetCenterLocation() {
     val location = MockLocation.createMockLocation(latitude = 10.0, longitude = 34.7)
     mapViewModel.setCenterLocation(location)
-    assertEquals(location.latitude,mapViewModel.centerLocation.value?.latitude)
-    assertEquals(location.longitude,mapViewModel.centerLocation.value?.longitude)
+    assertEquals(location.latitude, mapViewModel.centerLocation.value?.latitude)
+    assertEquals(location.longitude, mapViewModel.centerLocation.value?.longitude)
   }
 }


### PR DESCRIPTION
Link the map button in EventDetails to the map screen, such that the map is centered to the event in question.

For that I need to :
-> add a centerLocation stateflow in MapViewModel
-> add a setCenterLocation method in MapViewModel
-> modify the map screen accordingly

How it works:
in Home: simply navigate to Map without specifying any location, this will focus on userLocation
in EventDetails : use setCenterLocation method to 