### PR TITLE
Implement start and end date for events

### DIFF
--- a/app/src/main/java/com/android/unio/mocks/event/MockEvent.kt
+++ b/app/src/main/java/com/android/unio/mocks/event/MockEvent.kt
@@ -107,7 +107,7 @@ class MockEvent {
           description = description,
           catchyDescription = catchyDescription,
           price = price,
-          date = date,
+          startDate = date,
           location = location,
           types = types,
           placesRemaining = -1)

--- a/app/src/main/java/com/android/unio/model/event/Event.kt
+++ b/app/src/main/java/com/android/unio/model/event/Event.kt
@@ -32,7 +32,7 @@ import java.util.Date
  * @property description event description
  * @property catchyDescription event catchy description
  * @property price event price
- * @property date event date
+ * @property startDate event date
  * @property location event location
  * @property types list of event types
  */
@@ -45,7 +45,8 @@ data class Event(
     val description: String = "",
     val catchyDescription: String = "",
     val price: Double = 0.0,
-    val date: Timestamp = Timestamp(Date()),
+    val startDate: Timestamp = Timestamp(Date()),
+    val endDate: Timestamp = Timestamp(Date()),
     val location: Location = Location(),
     val types: List<EventType> = mutableListOf(EventType.OTHER),
     val placesRemaining: Int = -1

--- a/app/src/main/java/com/android/unio/model/event/EventRepositoryMock.kt
+++ b/app/src/main/java/com/android/unio/model/event/EventRepositoryMock.kt
@@ -40,7 +40,7 @@ open class EventRepositoryMock @Inject constructor() : EventRepository {
                       "The Summer Festival features live music, food stalls, and various activities for all ages.",
                   catchyDescription = "Come to the best event of the Coaching IC!",
                   price = 0.0,
-                  date = Timestamp(Date(2024 - 1900, 6, 20)), // July 20, 2024
+                  startDate = Timestamp(Date(2024 - 1900, 6, 20)), // July 20, 2024
                   location = Location(0.0, 0.0, "USA"),
                   types = listOf(EventType.TRIP),
                   placesRemaining = -1),
@@ -54,7 +54,7 @@ open class EventRepositoryMock @Inject constructor() : EventRepository {
                       "An evening of networking with industry leaders and innovators. Don't miss out!",
                   catchyDescription = "There never enough beersssssss!",
                   price = 10.0,
-                  date = Timestamp(Date(2024 - 1900, 4, 15)), // May 15, 2024
+                  startDate = Timestamp(Date(2024 - 1900, 4, 15)), // May 15, 2024
                   location = Location(1.0, 1.0, "USA"),
                   types = listOf(EventType.OTHER),
                   placesRemaining = -1),
@@ -68,7 +68,7 @@ open class EventRepositoryMock @Inject constructor() : EventRepository {
                       "Learn Kotlin from scratch with real-world examples and expert guidance.",
                   catchyDescription = "Don't miss the chant de section!",
                   price = 0.0,
-                  date = Timestamp(Date(2024 - 1900, 2, 10)), // March 10, 2024
+                  startDate = Timestamp(Date(2024 - 1900, 2, 10)), // March 10, 2024
                   location = Location(2.0, 2.0, "USA"),
                   types = listOf(EventType.OTHER),
                   placesRemaining = -1),
@@ -82,7 +82,7 @@ open class EventRepositoryMock @Inject constructor() : EventRepository {
                       "Join us for an unforgettable evening featuring local artists and musicians.",
                   catchyDescription = "Venez, il y a des gens sympa!",
                   price = 0.0,
-                  date = Timestamp(Date(2024 - 1900, 8, 25)), // September 25, 2024
+                  startDate = Timestamp(Date(2024 - 1900, 8, 25)), // September 25, 2024
                   location = Location(3.0, 3.0, "USA"),
                   types = listOf(EventType.OTHER),
                   placesRemaining = -1),
@@ -96,7 +96,7 @@ open class EventRepositoryMock @Inject constructor() : EventRepository {
                       "Participate in various sports activities and enjoy food and entertainment.",
                   catchyDescription = "Pick the best one!",
                   price = 5.0,
-                  date = Timestamp(Date(2024 - 1900, 5, 5)), // June 5, 2024
+                  startDate = Timestamp(Date(2024 - 1900, 5, 5)), // June 5, 2024
                   location = Location(4.0, 4.0, "USA"),
                   types = listOf(EventType.SPORT),
                   placesRemaining = -1),
@@ -110,7 +110,7 @@ open class EventRepositoryMock @Inject constructor() : EventRepository {
                       "A workshop dedicated to teaching strategies for successful social media marketing.",
                   catchyDescription = "Best concert everrrrr!",
                   price = 15.0,
-                  date = Timestamp(Date(2024 - 1900, 7, 30)), // August 30, 2024
+                  startDate = Timestamp(Date(2024 - 1900, 7, 30)), // August 30, 2024
                   location = Location(5.0, 5.0, "USA"),
                   types = listOf(EventType.OTHER),
                   placesRemaining = -1),
@@ -124,7 +124,7 @@ open class EventRepositoryMock @Inject constructor() : EventRepository {
                       "An evening of music with local artists. Bring your instruments or just enjoy the show!",
                   catchyDescription = "Support local talent in this open jam session!",
                   price = 0.0,
-                  date = Timestamp(Date(2024 - 1900, 3, 12)), // April 12, 2024
+                  startDate = Timestamp(Date(2024 - 1900, 3, 12)), // April 12, 2024
                   location = Location(6.0, 6.0, "USA"),
                   types = listOf(EventType.JAM),
                   placesRemaining = -1))
@@ -161,7 +161,8 @@ open class EventRepositoryMock @Inject constructor() : EventRepository {
       onFailure: (Exception) -> Unit
   ) {
     // Filter mock events by date range
-    getEvents({ events -> onSuccess(events.filter { it.date in startDate..endDate }) }, onFailure)
+    getEvents(
+        { events -> onSuccess(events.filter { it.startDate in startDate..endDate }) }, onFailure)
   }
 
   // Mock implementation to generate a new UID

--- a/app/src/main/java/com/android/unio/model/firestore/transform/Hydration.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Hydration.kt
@@ -95,7 +95,8 @@ fun EventRepositoryFirestore.Companion.hydrate(data: Map<String, Any>?): Event {
       description = data?.get(Event::description.name) as? String ?: "",
       catchyDescription = data?.get(Event::catchyDescription.name) as? String ?: "",
       price = data?.get(Event::price.name) as? Double ?: 0.0,
-      date = data?.get(Event::date.name) as? Timestamp ?: Timestamp(0, 0),
+      startDate = data?.get(Event::startDate.name) as? Timestamp ?: Timestamp(0, 0),
+      endDate = data?.get(Event::endDate.name) as? Timestamp ?: Timestamp(0, 0),
       location =
           Location(
               latitude = location.get(Location::latitude.name) as? Double ?: 0.0,

--- a/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
@@ -52,7 +52,8 @@ fun EventRepositoryFirestore.Companion.serialize(event: Event): Map<String, Any>
       Event::description.name to event.description,
       Event::catchyDescription.name to event.catchyDescription,
       Event::price.name to event.price,
-      Event::date.name to event.date,
+      Event::startDate.name to event.startDate,
+      Event::endDate.name to event.endDate,
       Event::location.name to
           mapOf(
               Location::latitude.name to event.location.latitude,

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -423,7 +423,7 @@ private fun AssociationEvents(
         context.getString(R.string.association_upcoming_events),
         modifier = Modifier.testTag(AssociationProfileTestTags.EVENT_TITLE),
         style = AppTypography.headlineMedium)
-    events.sortedBy { it.date }
+    events.sortedBy { it.startDate }
     val first = events.first()
     Column(modifier = Modifier, horizontalAlignment = Alignment.CenterHorizontally) {
       if (isSeeMoreClicked) {

--- a/app/src/main/java/com/android/unio/ui/event/EventCard.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCard.kt
@@ -230,7 +230,9 @@ fun EventCardScaffold(
                 modifier =
                     Modifier.padding(vertical = 1.dp, horizontal = 0.dp)
                         .testTag(EventCardTestTags.EVENT_DATE),
-                text = formatTimestamp(event.date, SimpleDateFormat("dd/MM", Locale.getDefault())),
+                text =
+                    formatTimestamp(
+                        event.startDate, SimpleDateFormat("dd/MM", Locale.getDefault())),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface)
 
@@ -248,7 +250,9 @@ fun EventCardScaffold(
 
             Text(
                 modifier = Modifier.testTag(EventCardTestTags.EVENT_TIME).wrapContentWidth(),
-                text = formatTimestamp(event.date, SimpleDateFormat("HH:mm", Locale.getDefault())),
+                text =
+                    formatTimestamp(
+                        event.startDate, SimpleDateFormat("HH:mm", Locale.getDefault())),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface)
           }

--- a/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventDetails.kt
@@ -257,11 +257,11 @@ fun EventInformationCard(event: Event, associations: List<Association>, context:
         }
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
           Text(
-              formatTimestamp(event.date, SimpleDateFormat("HH:mm", Locale.getDefault())),
+              formatTimestamp(event.startDate, SimpleDateFormat("HH:mm", Locale.getDefault())),
               modifier = Modifier.testTag(EventDetailsTestTags.START_HOUR),
               color = MaterialTheme.colorScheme.onPrimary)
           Text(
-              formatTimestamp(event.date, SimpleDateFormat("dd/MM", Locale.getDefault())),
+              formatTimestamp(event.startDate, SimpleDateFormat("dd/MM", Locale.getDefault())),
               modifier = Modifier.testTag(EventDetailsTestTags.DATE),
               color = MaterialTheme.colorScheme.onPrimary)
         }

--- a/app/src/main/java/com/android/unio/ui/map/Map.kt
+++ b/app/src/main/java/com/android/unio/ui/map/Map.kt
@@ -212,7 +212,7 @@ fun EventMap(
 
         // Display saved events
         savedEvents.forEach { event ->
-          if (event.date.toDate() > Calendar.getInstance().time) {
+          if (event.startDate.toDate() > Calendar.getInstance().time) {
             DisplayEventMarker(event, R.drawable.favorite_pinpoint)
           }
         }
@@ -222,7 +222,7 @@ fun EventMap(
         events.value
             .filterNot { event -> savedEvents.any { it.uid == event.uid } }
             .forEach { event ->
-              if (event.date.toDate() > Calendar.getInstance().time) {
+              if (event.startDate.toDate() > Calendar.getInstance().time) {
                 DisplayEventMarker(event, null)
               }
             }
@@ -238,7 +238,7 @@ fun EventMap(
  */
 @Composable
 fun DisplayEventMarker(event: Event, customIconResId: Int?) {
-  val timer = timeUntilEvent(event.date)
+  val timer = timeUntilEvent(event.startDate)
   event.location.let { location ->
     val pinPointIcon =
         if (customIconResId != null) {

--- a/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
+++ b/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
@@ -60,7 +60,7 @@ class HydrationAndSerializationTest {
           description = "An example event",
           catchyDescription = "An example event",
           price = 0.0,
-          date = Timestamp.now(),
+          startDate = Timestamp.now(),
           location = Location(latitude = 0.0, longitude = 0.0, name = "Example Location"),
           placesRemaining = -1)
 
@@ -131,7 +131,8 @@ class HydrationAndSerializationTest {
     assertEquals(event.description, serialized["description"])
     assertEquals(event.catchyDescription, serialized["catchyDescription"])
     assertEquals(event.price, serialized["price"])
-    assertEquals(event.date, serialized["date"])
+    assertEquals(event.startDate, serialized["startDate"])
+    assertEquals(event.endDate, serialized["endDate"])
     assertEquals(event.location.name, (serialized["location"] as Map<String, Any>)["name"])
     assertEquals(event.location.latitude, (serialized["location"] as Map<String, Any>)["latitude"])
     assertEquals(
@@ -148,7 +149,7 @@ class HydrationAndSerializationTest {
     assertEquals(event.description, hydrated.description)
     assertEquals(event.catchyDescription, hydrated.catchyDescription)
     assertEquals(event.price, hydrated.price)
-    assertEquals(event.date, hydrated.date)
+    assertEquals(event.startDate, hydrated.startDate)
     assertEquals(event.location, hydrated.location)
     assertEquals(event.organisers.uids, hydrated.organisers.uids)
     assertEquals(event.taggedAssociations.uids, hydrated.taggedAssociations.uids)
@@ -202,7 +203,8 @@ class HydrationAndSerializationTest {
     assertEquals("", hydrated.description)
     assertEquals("", hydrated.catchyDescription)
     assertEquals(0.0, hydrated.price)
-    assertEquals(Timestamp(0, 0), hydrated.date)
+    assertEquals(Timestamp(0, 0), hydrated.startDate)
+    assertEquals(Timestamp(0, 0), hydrated.endDate)
     assertEquals(Location(), hydrated.location)
     assertEquals(emptyList<Association>(), hydrated.organisers.list.value)
     assertEquals(emptyList<Association>(), hydrated.taggedAssociations.list.value)

--- a/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
@@ -108,7 +108,7 @@ class SearchRepositoryTest {
           image = "https://imageurl.jpg",
           description = "Plus grand festival du monde (non contractuel)",
           price = 40.5,
-          date = Timestamp(GregorianCalendar(2004, 7, 1).time),
+          startDate = Timestamp(GregorianCalendar(2004, 7, 1).time),
           location = Location(1.2345, 2.3455, "Somewhere"),
           placesRemaining = -1)
   private val event2 =
@@ -120,7 +120,7 @@ class SearchRepositoryTest {
           image = "https://imageurl.jpg",
           description = "Plus grand festival du monde (non contractuel)",
           price = 40.5,
-          date = Timestamp(GregorianCalendar(2008, 7, 1).time),
+          startDate = Timestamp(GregorianCalendar(2008, 7, 1).time),
           location = Location(1.2345, 2.3455, "Somewhere"),
           placesRemaining = -1)
 


### PR DESCRIPTION
As of now we only had a single date for events, e.g the event's start date. But this isn't enough information as we would like to know the event's duration, as well as inform the users of the hour/ day on which the event ends.

So this PR includes:
-> refactor of the Event data class to include startDate and endDate.
-> Change EventDetails.kt accordingly so that it displays these informations in a nice manner
-> Maybe also modify EventCard (TO BE DEBATED: do we need the endDate on EventCard ?)