### PR TITLE
Feature/event creation backend

### DIFF
--- a/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
@@ -249,7 +249,7 @@ class ScreenDisplayingTest {
   @Test
   fun testEventCreationDisplayed() {
     composeTestRule.setContent {
-      EventCreationScreen(navigationAction, searchViewModel, associationViewModel)
+      EventCreationScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel)
     }
     composeTestRule.onNodeWithTag(EventCreationTestTags.SCREEN).assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/android/unio/ui/event/EventCreationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/event/EventCreationTest.kt
@@ -50,9 +50,9 @@ class EventCreationTest {
   @get:Rule val composeTestRule = createComposeRule()
   @get:Rule val hiltRule = HiltAndroidRule(this)
 
-    val events = listOf(MockEvent.createMockEvent())
-    @MockK private lateinit var eventRepository: EventRepositoryFirestore
-    private lateinit var eventViewModel: EventViewModel
+  val events = listOf(MockEvent.createMockEvent())
+  @MockK private lateinit var eventRepository: EventRepositoryFirestore
+  private lateinit var eventViewModel: EventViewModel
 
   private lateinit var searchViewModel: SearchViewModel
   @MockK(relaxed = true) private lateinit var searchRepository: SearchRepository
@@ -74,12 +74,12 @@ class EventCreationTest {
     every { Firebase.auth } returns firebaseAuth
     every { firebaseAuth.currentUser } returns mockFirebaseUser
 
-      every { eventRepository.getEvents(any(), any()) } answers
-              {
-                  val onSuccess = args[0] as (List<Event>) -> Unit
-                  onSuccess(events)
-              }
-      eventViewModel = EventViewModel(eventRepository, imageRepositoryFirestore)
+    every { eventRepository.getEvents(any(), any()) } answers
+        {
+          val onSuccess = args[0] as (List<Event>) -> Unit
+          onSuccess(events)
+        }
+    eventViewModel = EventViewModel(eventRepository, imageRepositoryFirestore)
 
     searchViewModel = spyk(SearchViewModel(searchRepository))
     associationViewModel =

--- a/app/src/androidTest/java/com/android/unio/ui/event/EventCreationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/event/EventCreationTest.kt
@@ -8,11 +8,13 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.android.unio.mocks.association.MockAssociation
+import com.android.unio.mocks.event.MockEvent
 import com.android.unio.mocks.user.MockUser
 import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.association.AssociationViewModel
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepositoryFirestore
+import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.follow.ConcurrentAssociationUserRepositoryFirestore
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
 import com.android.unio.model.search.SearchRepository
@@ -48,6 +50,10 @@ class EventCreationTest {
   @get:Rule val composeTestRule = createComposeRule()
   @get:Rule val hiltRule = HiltAndroidRule(this)
 
+    val events = listOf(MockEvent.createMockEvent())
+    @MockK private lateinit var eventRepository: EventRepositoryFirestore
+    private lateinit var eventViewModel: EventViewModel
+
   private lateinit var searchViewModel: SearchViewModel
   @MockK(relaxed = true) private lateinit var searchRepository: SearchRepository
 
@@ -67,6 +73,13 @@ class EventCreationTest {
     mockkStatic(FirebaseAuth::class)
     every { Firebase.auth } returns firebaseAuth
     every { firebaseAuth.currentUser } returns mockFirebaseUser
+
+      every { eventRepository.getEvents(any(), any()) } answers
+              {
+                  val onSuccess = args[0] as (List<Event>) -> Unit
+                  onSuccess(events)
+              }
+      eventViewModel = EventViewModel(eventRepository, imageRepositoryFirestore)
 
     searchViewModel = spyk(SearchViewModel(searchRepository))
     associationViewModel =
@@ -90,7 +103,7 @@ class EventCreationTest {
   @Test
   fun testEventCreationTagsDisplayed() {
     composeTestRule.setContent {
-      EventCreationScreen(navigationAction, searchViewModel, associationViewModel)
+      EventCreationScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel)
     }
 
     composeTestRule.waitForIdle()

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -135,12 +135,12 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
         EditAssociationScreen(associationViewModel, navigationActions)
       }
       composable(Screen.EVENT_CREATION) {
-        EventCreationScreen(navigationActions, searchViewModel, associationViewModel)
+        EventCreationScreen(navigationActions, searchViewModel, associationViewModel, eventViewModel)
       }
       composable(Screen.SOMEONE_ELSE_PROFILE) {
         SomeoneElseUserProfileScreen(navigationActions, userViewModel)
         composable(Screen.EVENT_CREATION) {
-          EventCreationScreen(navigationActions, searchViewModel, associationViewModel)
+          EventCreationScreen(navigationActions, searchViewModel, associationViewModel, eventViewModel)
         }
       }
       navigation(startDestination = Screen.SAVED, route = Route.SAVED) {

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -135,12 +135,14 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
         EditAssociationScreen(associationViewModel, navigationActions)
       }
       composable(Screen.EVENT_CREATION) {
-        EventCreationScreen(navigationActions, searchViewModel, associationViewModel, eventViewModel)
+        EventCreationScreen(
+            navigationActions, searchViewModel, associationViewModel, eventViewModel)
       }
       composable(Screen.SOMEONE_ELSE_PROFILE) {
         SomeoneElseUserProfileScreen(navigationActions, userViewModel)
         composable(Screen.EVENT_CREATION) {
-          EventCreationScreen(navigationActions, searchViewModel, associationViewModel, eventViewModel)
+          EventCreationScreen(
+              navigationActions, searchViewModel, associationViewModel, eventViewModel)
         }
       }
       navigation(startDestination = Screen.SAVED, route = Route.SAVED) {

--- a/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
@@ -90,12 +90,12 @@ constructor(private val repository: EventRepository, private val imageRepository
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
+    event.uid = repository.getNewUid() // Generate a new UID for the event
     imageRepository.uploadImage(
         inputStream,
         "images/events/${event.uid}",
         { uri ->
           event.image = uri
-          event.uid = repository.getNewUid()
           repository.addEvent(event, onSuccess, onFailure)
         },
         { e -> Log.e("ImageRepository", "Failed to store image: $e") })

--- a/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
@@ -83,7 +83,10 @@ constructor(private val repository: EventRepository, private val imageRepository
     return _events.value.find { it.uid == id }
   }
 
-  /** Add a new event to the repository. It uploads the event image first, then adds the event. */
+  /**
+   * Add a new event to the repository. It uploads the event image first, then adds the event. It
+   * then adds it to the _events stateflow
+   */
   fun addEvent(
       inputStream: InputStream,
       event: Event,
@@ -99,5 +102,6 @@ constructor(private val repository: EventRepository, private val imageRepository
           repository.addEvent(event, onSuccess, onFailure)
         },
         { e -> Log.e("ImageRepository", "Failed to store image: $e") })
+    _events.value += event
   }
 }

--- a/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
@@ -102,6 +102,7 @@ constructor(private val repository: EventRepository, private val imageRepository
           repository.addEvent(event, onSuccess, onFailure)
         },
         { e -> Log.e("ImageRepository", "Failed to store image: $e") })
+    event.organisers.requestAll(onSuccess)
     _events.value += event
   }
 }

--- a/app/src/main/java/com/android/unio/model/strings/test_tags/EventTestTags.kt
+++ b/app/src/main/java/com/android/unio/model/strings/test_tags/EventTestTags.kt
@@ -25,6 +25,8 @@ object EventCreationTestTags {
   const val EVENT_IMAGE = "eventCreationEventImage"
   const val START_TIME = "eventCreationStartTime"
   const val END_TIME = "eventCreationEndTime"
+  const val ERROR_TEXT1 = "eventCreationStartAfterEnd"
+  const val ERROR_TEXT2 = "eventCreationStartEqualsEnd"
 }
 
 object EventCreationOverlayTestTags {

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -1,12 +1,10 @@
 package com.android.unio.ui.event
 
 import android.net.Uri
-import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
@@ -87,7 +85,6 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-@RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
 fun EventCreationScreen(
     navigationAction: NavigationAction,

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -1,7 +1,6 @@
 package com.android.unio.ui.event
 
 import android.net.Uri
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -256,7 +255,11 @@ fun EventCreationScreen(
                     ),
                     onSuccess = { navigationAction.goBack() },
                     onFailure = {
-                      Toast.makeText(context, context.getString(R.string.event_creation_failed), Toast.LENGTH_SHORT).show()
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.event_creation_failed),
+                              Toast.LENGTH_SHORT)
+                          .show()
                     })
               }) {
                 Text(context.getString(R.string.event_creation_save_button))

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccessTime
@@ -109,8 +108,8 @@ fun EventCreationScreen(
   var taggedAndBoolean =
       associationViewModel.associations.collectAsState().value.map { it to mutableStateOf(false) }
 
-  var startTimestamp : Timestamp? by remember { mutableStateOf(null) }
-  var endTimestamp : Timestamp? by remember { mutableStateOf(null) }
+  var startTimestamp: Timestamp? by remember { mutableStateOf(null) }
+  var endTimestamp: Timestamp? by remember { mutableStateOf(null) }
 
   val eventBannerUri = remember { mutableStateOf<Uri>(Uri.EMPTY) }
 
@@ -196,8 +195,7 @@ fun EventCreationScreen(
             Text(
                 text = "Event cannot start after it ends",
                 modifier = Modifier.testTag("NoEventBeforeEnd"),
-                color = MaterialTheme.colorScheme.error
-            )
+                color = MaterialTheme.colorScheme.error)
           }
 
           OutlinedTextField(
@@ -218,8 +216,9 @@ fun EventCreationScreen(
                   name.isNotEmpty() &&
                       shortDescription.isNotEmpty() &&
                       longDescription.isNotEmpty() &&
-                      startTimestamp != null && endTimestamp != null &&
-                          startTimestamp!! < endTimestamp!! &&
+                      startTimestamp != null &&
+                      endTimestamp != null &&
+                      startTimestamp!! < endTimestamp!! &&
                       eventBannerUri.value != Uri.EMPTY,
               onClick = {
                 val inputStream = context.contentResolver.openInputStream(eventBannerUri.value)!!

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccessTime
@@ -39,6 +40,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -107,8 +109,8 @@ fun EventCreationScreen(
   var taggedAndBoolean =
       associationViewModel.associations.collectAsState().value.map { it to mutableStateOf(false) }
 
-  var startTimestamp by remember { mutableStateOf(Timestamp.now()) }
-  var endTimestamp by remember { mutableStateOf(Timestamp.now()) }
+  var startTimestamp : Timestamp? by remember { mutableStateOf(null) }
+  var endTimestamp : Timestamp? by remember { mutableStateOf(null) }
 
   val eventBannerUri = remember { mutableStateOf<Uri>(Uri.EMPTY) }
 
@@ -190,6 +192,13 @@ fun EventCreationScreen(
               modifier = Modifier.testTag(EventCreationTestTags.END_TIME)) {
                 endTimestamp = it
               }
+          if (startTimestamp != null && endTimestamp != null && startTimestamp!! > endTimestamp!!) {
+            Text(
+                text = "Event cannot start after it ends",
+                modifier = Modifier.testTag("NoEventBeforeEnd"),
+                color = MaterialTheme.colorScheme.error
+            )
+          }
 
           OutlinedTextField(
               modifier =
@@ -209,9 +218,9 @@ fun EventCreationScreen(
                   name.isNotEmpty() &&
                       shortDescription.isNotEmpty() &&
                       longDescription.isNotEmpty() &&
-                      startTimestamp.seconds < endTimestamp.seconds &&
-                      eventBannerUri.value != Uri.EMPTY &&
-                      coauthorsAndBoolean.any { it.second.value },
+                      startTimestamp != null && endTimestamp != null &&
+                          startTimestamp!! < endTimestamp!! &&
+                      eventBannerUri.value != Uri.EMPTY,
               onClick = {
                 val inputStream = context.contentResolver.openInputStream(eventBannerUri.value)!!
                 eventViewModel.addEvent(
@@ -233,8 +242,8 @@ fun EventCreationScreen(
                         description = longDescription,
                         catchyDescription = shortDescription,
                         price = 0.0,
-                        startDate = startTimestamp,
-                        endDate = endTimestamp,
+                        startDate = startTimestamp!!,
+                        endDate = endTimestamp!!,
                         location = Location(),
                     ),
                     onSuccess = { navigationAction.goBack() },

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -113,9 +113,9 @@ fun EventCreationScreen(
   var startTimestamp by remember { mutableStateOf(Timestamp.now()) }
   var endTimestamp by remember { mutableStateOf(Timestamp.now()) }
 
-    val eventBannerUri = remember { mutableStateOf<Uri>(Uri.EMPTY) }
+  val eventBannerUri = remember { mutableStateOf<Uri>(Uri.EMPTY) }
 
-    Scaffold(modifier = Modifier.testTag(EventCreationTestTags.SCREEN)) { padding ->
+  Scaffold(modifier = Modifier.testTag(EventCreationTestTags.SCREEN)) { padding ->
     Column(
         modifier =
             Modifier.padding(padding).padding(20.dp).fillMaxWidth().verticalScroll(scrollState),
@@ -183,18 +183,18 @@ fun EventCreationScreen(
           DateAndTimePicker(
               context.getString(R.string.event_creation_startdate_label),
               context.getString(R.string.event_creation_starttime_label),
-              modifier = Modifier.testTag(EventCreationTestTags.START_TIME)
-          ) { startTimestamp = it }
+              modifier = Modifier.testTag(EventCreationTestTags.START_TIME)) {
+                startTimestamp = it
+              }
 
-        DateAndTimePicker(
+          DateAndTimePicker(
               context.getString(R.string.event_creation_enddate_label),
               context.getString(R.string.event_creation_endtime_label),
-              modifier = Modifier.testTag(EventCreationTestTags.END_TIME)
-        ) {
-            endTimestamp = it
-        }
+              modifier = Modifier.testTag(EventCreationTestTags.END_TIME)) {
+                endTimestamp = it
+              }
 
-        OutlinedTextField(
+          OutlinedTextField(
               modifier =
                   Modifier.fillMaxWidth().testTag(EventCreationTestTags.LOCATION).clickable {
                     Toast.makeText(context, "Location is not implemented yet", Toast.LENGTH_SHORT)
@@ -208,12 +208,13 @@ fun EventCreationScreen(
 
           Button(
               modifier = Modifier.testTag(EventCreationTestTags.SAVE_BUTTON),
-              enabled = name.isNotEmpty()
-                      && shortDescription.isNotEmpty()
-                      && longDescription.isNotEmpty()
-                      && startTimestamp.seconds < endTimestamp.seconds
-                      && eventBannerUri.value != Uri.EMPTY
-                      && coauthorsAndBoolean.any { it.second.value },
+              enabled =
+                  name.isNotEmpty() &&
+                      shortDescription.isNotEmpty() &&
+                      longDescription.isNotEmpty() &&
+                      startTimestamp.seconds < endTimestamp.seconds &&
+                      eventBannerUri.value != Uri.EMPTY &&
+                      coauthorsAndBoolean.any { it.second.value },
               onClick = {
                 val inputStream = context.contentResolver.openInputStream(eventBannerUri.value)!!
                 eventViewModel.addEvent(
@@ -221,14 +222,16 @@ fun EventCreationScreen(
                     Event(
                         uid = "", // This gets overwritten by eventViewModel.addEvent
                         title = name,
-                        organisers = Association.firestoreReferenceListWith(
-                            coauthorsAndBoolean.filter { it.second.value }
-                            .map { it.first.uid }
-                        ),
-                        taggedAssociations = Association.firestoreReferenceListWith(
-                            taggedAndBoolean.filter { it.second.value }
-                                .map { it.first.uid }
-                        ),
+                        organisers =
+                            Association.firestoreReferenceListWith(
+                                (coauthorsAndBoolean
+                                        .filter { it.second.value }
+                                        .map { it.first.uid } +
+                                        associationViewModel.selectedAssociation.value!!.uid)
+                                    .distinct()),
+                        taggedAssociations =
+                            Association.firestoreReferenceListWith(
+                                taggedAndBoolean.filter { it.second.value }.map { it.first.uid }),
                         image = eventBannerUri.value.toString(),
                         description = longDescription,
                         catchyDescription = shortDescription,
@@ -238,8 +241,9 @@ fun EventCreationScreen(
                         location = Location(),
                     ),
                     onSuccess = { navigationAction.goBack() },
-                    onFailure = { Toast.makeText(context, "Failed to create event", Toast.LENGTH_SHORT).show() }
-                )
+                    onFailure = {
+                      Toast.makeText(context, "Failed to create event", Toast.LENGTH_SHORT).show()
+                    })
               }) {
                 Text(context.getString(R.string.event_creation_save_button))
               }
@@ -338,11 +342,12 @@ private fun BannerImagePicker(eventBannerUri: MutableState<Uri>) {
 }
 
 @Composable
-private fun DateAndTimePicker(dateString: String,
-                              timeString: String,
-                              modifier: Modifier,
-                              onTimestamp: (Timestamp) -> Unit
-                              ) {
+private fun DateAndTimePicker(
+    dateString: String,
+    timeString: String,
+    modifier: Modifier,
+    onTimestamp: (Timestamp) -> Unit
+) {
   var isDatePickerVisible by remember { mutableStateOf(false) }
   var isTimePickerVisible by remember { mutableStateOf(false) }
   var selectedDate by remember { mutableStateOf<Long?>(null) }
@@ -413,9 +418,9 @@ private fun DateAndTimePicker(dateString: String,
         onDismiss = { isTimePickerVisible = false })
   }
 
-    if (selectedDate != null && selectedTime != null) {
-        onTimestamp(Timestamp(Date(selectedDate!! + selectedTime!!)))
-    }
+  if (selectedDate != null && selectedTime != null) {
+    onTimestamp(Timestamp(Date(selectedDate!! + selectedTime!!)))
+  }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -69,6 +69,7 @@ import coil.compose.rememberAsyncImagePainter
 import com.android.unio.R
 import com.android.unio.model.association.Association
 import com.android.unio.model.association.AssociationViewModel
+import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.strings.FormatStrings.DAY_MONTH_YEAR_FORMAT
 import com.android.unio.model.strings.FormatStrings.HOUR_MINUTE_FORMAT
@@ -84,15 +85,17 @@ import java.util.Locale
 fun EventCreationScreen(
     navigationAction: NavigationAction,
     searchViewModel: SearchViewModel,
-    associationViewModel: AssociationViewModel
+    associationViewModel: AssociationViewModel,
+    eventViewModel: EventViewModel
 ) {
   val context = LocalContext.current
-  var name by remember { mutableStateOf("") }
-  var shortDescription by remember { mutableStateOf("") }
-  var longDescription by remember { mutableStateOf("") }
   val scrollState = rememberScrollState()
   var showCoauthorsOverlay by remember { mutableStateOf(false) }
   var showTaggedOverlay by remember { mutableStateOf(false) }
+
+  var name by remember { mutableStateOf("") }
+  var shortDescription by remember { mutableStateOf("") }
+  var longDescription by remember { mutableStateOf("") }
 
   var coauthorsAndBoolean =
       associationViewModel.associations.collectAsState().value.map { it to mutableStateOf(false) }
@@ -188,7 +191,9 @@ fun EventCreationScreen(
 
           Button(
               modifier = Modifier.testTag(EventCreationTestTags.SAVE_BUTTON),
-              onClick = { navigationAction.goBack() }) {
+              onClick = {
+
+              }) {
                 Text(context.getString(R.string.event_creation_save_button))
               }
 

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -1,6 +1,7 @@
 package com.android.unio.ui.event
 
 import android.net.Uri
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -191,11 +192,19 @@ fun EventCreationScreen(
               modifier = Modifier.testTag(EventCreationTestTags.END_TIME)) {
                 endTimestamp = it
               }
-          if (startTimestamp != null && endTimestamp != null && startTimestamp!! > endTimestamp!!) {
-            Text(
-                text = "Event cannot start after it ends",
-                modifier = Modifier.testTag("NoEventBeforeEnd"),
-                color = MaterialTheme.colorScheme.error)
+          if (startTimestamp != null && endTimestamp != null) {
+            if (startTimestamp!! > endTimestamp!!) {
+              Text(
+                  text = "Event cannot start after it ends",
+                  modifier = Modifier.testTag("NoEventBeforeEnd"),
+                  color = MaterialTheme.colorScheme.error)
+            }
+            if (startTimestamp!! == endTimestamp!!) {
+              Text(
+                  text = "Event cannot start and end at the same time",
+                  modifier = Modifier.testTag("NoEventSameTime"),
+                  color = MaterialTheme.colorScheme.error)
+            }
           }
 
           OutlinedTextField(
@@ -222,6 +231,12 @@ fun EventCreationScreen(
                       eventBannerUri.value != Uri.EMPTY,
               onClick = {
                 val inputStream = context.contentResolver.openInputStream(eventBannerUri.value)!!
+
+                val test =
+                    (coauthorsAndBoolean.filter { it.second.value }.map { it.first.uid } +
+                            associationViewModel.selectedAssociation.value!!.uid)
+                        .distinct()
+                Log.d("EventCreationScreen", "Associations: $test")
                 eventViewModel.addEvent(
                     inputStream,
                     Event(

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -195,14 +195,14 @@ fun EventCreationScreen(
           if (startTimestamp != null && endTimestamp != null) {
             if (startTimestamp!! > endTimestamp!!) {
               Text(
-                  text = "Event cannot start after it ends",
-                  modifier = Modifier.testTag("NoEventBeforeEnd"),
+                  text = context.getString(R.string.event_creation_end_before_start),
+                  modifier = Modifier.testTag(EventCreationTestTags.ERROR_TEXT1),
                   color = MaterialTheme.colorScheme.error)
             }
             if (startTimestamp!! == endTimestamp!!) {
               Text(
-                  text = "Event cannot start and end at the same time",
-                  modifier = Modifier.testTag("NoEventSameTime"),
+                  text = context.getString(R.string.event_creation_end_equals_start),
+                  modifier = Modifier.testTag(EventCreationTestTags.ERROR_TEXT2),
                   color = MaterialTheme.colorScheme.error)
             }
           }
@@ -231,12 +231,6 @@ fun EventCreationScreen(
                       eventBannerUri.value != Uri.EMPTY,
               onClick = {
                 val inputStream = context.contentResolver.openInputStream(eventBannerUri.value)!!
-
-                val test =
-                    (coauthorsAndBoolean.filter { it.second.value }.map { it.first.uid } +
-                            associationViewModel.selectedAssociation.value!!.uid)
-                        .distinct()
-                Log.d("EventCreationScreen", "Associations: $test")
                 eventViewModel.addEvent(
                     inputStream,
                     Event(
@@ -262,7 +256,7 @@ fun EventCreationScreen(
                     ),
                     onSuccess = { navigationAction.goBack() },
                     onFailure = {
-                      Toast.makeText(context, "Failed to create event", Toast.LENGTH_SHORT).show()
+                      Toast.makeText(context, context.getString(R.string.event_creation_failed), Toast.LENGTH_SHORT).show()
                     })
               }) {
                 Text(context.getString(R.string.event_creation_save_button))

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -155,6 +155,9 @@
     <string name="event_creation_enddate_label">Date de fin</string>
     <string name="event_creation_starttime_label">Heure de début</string>
     <string name="event_creation_endtime_label">Heure de fin</string>
+    <string name="event_creation_end_before_start">L\'heure de fin doit être avant celle de début</string>
+    <string name="event_creation_end_equals_start">L\'heure de fin ne peut pas être l\'heure de début</string>
+    <string name="event_creation_failed">Echec lors de la création</string>
 
     <!-- Associations Overlay Strings -->
     <string name="associations_overlay_coauthors_title" translatable="true">Co-organisateurs</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,10 @@
     <string name="event_creation_enddate_label">End Date</string>
     <string name="event_creation_starttime_label">Start Time</string>
     <string name="event_creation_endtime_label">End Time</string>
+    <string name="event_creation_end_before_start">Event cannot start after it ends</string>
+    <string name="event_creation_end_equals_start">Event cannot start and end at the same time</string>
+    <string name="event_creation_failed">Failed to create event</string>
+
 
     <!-- Associations Overlay Strings -->
     <string name="associations_overlay_coauthors_title" translatable="true">Coauthors</string>


### PR DESCRIPTION
This PR aims to connect the event creation UI to the Firestore database. It modifies the EventCreation file to call eventViewModel.addEvent in the onClick of the create button and does all the required changes for it to work. It enforces a light check on the user arguments (ensures they are non-null and that the startTime < endTime). 
This is however being put as a draft for the moment as there are no tests at the moment and I'd like to test this with the firebase emulator.