### PR TITLE
feat: implement Places Search API 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -187,6 +187,7 @@ dependencies {
     implementation(libs.core)
     implementation(libs.firebase.functions.ktx)
     implementation(libs.play.services.location)
+    implementation(libs.places)
 
     testImplementation(libs.test.core.ktx)
     debugImplementation(libs.androidx.ui.tooling)

--- a/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
@@ -252,7 +252,12 @@ class ScreenDisplayingTest {
   @Test
   fun testEventCreationDisplayed() {
     composeTestRule.setContent {
-      EventCreationScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel, placesSearchViewModel)
+      EventCreationScreen(
+          navigationAction,
+          searchViewModel,
+          associationViewModel,
+          eventViewModel,
+          placesSearchViewModel)
     }
     composeTestRule.onNodeWithTag(EventCreationTestTags.SCREEN).assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/ScreenDisplayingTest.kt
@@ -16,6 +16,7 @@ import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.follow.ConcurrentAssociationUserRepositoryFirestore
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
 import com.android.unio.model.map.MapViewModel
+import com.android.unio.model.map.PlacesSearchViewModel
 import com.android.unio.model.search.SearchRepository
 import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.strings.test_tags.AccountDetailsTestTags
@@ -89,6 +90,8 @@ class ScreenDisplayingTest {
 
   @MockK private lateinit var eventRepository: EventRepositoryFirestore
   private lateinit var eventViewModel: EventViewModel
+
+  @MockK private lateinit var placesSearchViewModel: PlacesSearchViewModel
 
   // Mocking the mapViewModel and its dependencies
   private lateinit var locationTask: Task<Location>
@@ -249,7 +252,7 @@ class ScreenDisplayingTest {
   @Test
   fun testEventCreationDisplayed() {
     composeTestRule.setContent {
-      EventCreationScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel)
+      EventCreationScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel, placesSearchViewModel)
     }
     composeTestRule.onNodeWithTag(EventCreationTestTags.SCREEN).assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/android/unio/ui/event/EventCreationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/event/EventCreationTest.kt
@@ -13,6 +13,7 @@ import com.android.unio.model.event.EventRepositoryFirestore
 import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.follow.ConcurrentAssociationUserRepositoryFirestore
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
+import com.android.unio.model.map.PlacesSearchViewModel
 import com.android.unio.model.search.SearchRepository
 import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.strings.test_tags.EventCreationOverlayTestTags
@@ -62,6 +63,8 @@ class EventCreationTest {
   private lateinit var concurrentAssociationUserRepositoryFirestore:
       ConcurrentAssociationUserRepositoryFirestore
 
+  @MockK private lateinit var placesSearchViewModel: PlacesSearchViewModel
+
   @Before
   fun setUp() {
     MockKAnnotations.init(this, relaxed = true)
@@ -100,7 +103,7 @@ class EventCreationTest {
   @Test
   fun testEventCreationTagsDisplayed() {
     composeTestRule.setContent {
-      EventCreationScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel)
+      EventCreationScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel, placesSearchViewModel)
     }
 
     composeTestRule.waitForIdle()

--- a/app/src/androidTest/java/com/android/unio/ui/event/EventCreationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/ui/event/EventCreationTest.kt
@@ -103,7 +103,12 @@ class EventCreationTest {
   @Test
   fun testEventCreationTagsDisplayed() {
     composeTestRule.setContent {
-      EventCreationScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel, placesSearchViewModel)
+      EventCreationScreen(
+          navigationAction,
+          searchViewModel,
+          associationViewModel,
+          eventViewModel,
+          placesSearchViewModel)
     }
 
     composeTestRule.waitForIdle()

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -26,6 +26,7 @@ import com.android.unio.model.authentication.AuthViewModel
 import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
 import com.android.unio.model.map.MapViewModel
+import com.android.unio.model.map.PlacesSearchViewModel
 import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.user.UserViewModel
 import com.android.unio.ui.association.AssociationProfileScreen
@@ -85,6 +86,7 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
   val authViewModel = hiltViewModel<AuthViewModel>()
   val eventViewModel = hiltViewModel<EventViewModel>()
   val mapViewModel = hiltViewModel<MapViewModel>()
+  val placesSearchViewModel = hiltViewModel<PlacesSearchViewModel>()
 
   // Observe the authentication state
   val authState by authViewModel.authState.collectAsState()
@@ -138,13 +140,13 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
       }
       composable(Screen.EVENT_CREATION) {
         EventCreationScreen(
-            navigationActions, searchViewModel, associationViewModel, eventViewModel)
+            navigationActions, searchViewModel, associationViewModel, eventViewModel, placesSearchViewModel)
       }
       composable(Screen.SOMEONE_ELSE_PROFILE) {
         SomeoneElseUserProfileScreen(navigationActions, userViewModel, associationViewModel)
         composable(Screen.EVENT_CREATION) {
           EventCreationScreen(
-              navigationActions, searchViewModel, associationViewModel, eventViewModel)
+              navigationActions, searchViewModel, associationViewModel, eventViewModel, placesSearchViewModel)
         }
       }
     }

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -140,13 +140,21 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
       }
       composable(Screen.EVENT_CREATION) {
         EventCreationScreen(
-            navigationActions, searchViewModel, associationViewModel, eventViewModel, placesSearchViewModel)
+            navigationActions,
+            searchViewModel,
+            associationViewModel,
+            eventViewModel,
+            placesSearchViewModel)
       }
       composable(Screen.SOMEONE_ELSE_PROFILE) {
         SomeoneElseUserProfileScreen(navigationActions, userViewModel, associationViewModel)
         composable(Screen.EVENT_CREATION) {
           EventCreationScreen(
-              navigationActions, searchViewModel, associationViewModel, eventViewModel, placesSearchViewModel)
+              navigationActions,
+              searchViewModel,
+              associationViewModel,
+              eventViewModel,
+              placesSearchViewModel)
         }
       }
     }

--- a/app/src/main/java/com/android/unio/mocks/map/MockLocation.kt
+++ b/app/src/main/java/com/android/unio/mocks/map/MockLocation.kt
@@ -56,7 +56,7 @@ class MockLocation {
         longitude: Double = EdgeCaseLongitude.TYPICAL.value,
         name: String = EdgeCaseName.TYPICAL.value
     ): Location {
-      return Location(latitude = latitude, longitude =  longitude, name = name)
+      return Location(latitude = latitude, longitude = longitude, name = name)
     }
   }
 }

--- a/app/src/main/java/com/android/unio/mocks/map/MockLocation.kt
+++ b/app/src/main/java/com/android/unio/mocks/map/MockLocation.kt
@@ -56,7 +56,7 @@ class MockLocation {
         longitude: Double = EdgeCaseLongitude.TYPICAL.value,
         name: String = EdgeCaseName.TYPICAL.value
     ): Location {
-      return Location(latitude, longitude, name)
+      return Location(latitude = latitude, longitude =  longitude, name = name)
     }
   }
 }

--- a/app/src/main/java/com/android/unio/model/hilt/module/HiltModule.kt
+++ b/app/src/main/java/com/android/unio/model/hilt/module/HiltModule.kt
@@ -1,6 +1,8 @@
 package com.android.unio.model.hilt.module
 
 import android.content.Context
+import android.content.pm.PackageManager
+import com.android.unio.BuildConfig
 import com.android.unio.model.association.AssociationRepository
 import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.event.EventRepository
@@ -9,10 +11,14 @@ import com.android.unio.model.follow.ConcurrentAssociationUserRepository
 import com.android.unio.model.follow.ConcurrentAssociationUserRepositoryFirestore
 import com.android.unio.model.image.ImageRepository
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
+import com.android.unio.model.map.PlacesSearchRepository
+import com.android.unio.model.map.PlacesSearchRepositoryClient
 import com.android.unio.model.user.UserRepository
 import com.android.unio.model.user.UserRepositoryFirestore
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.google.android.libraries.places.api.Places
+import com.google.android.libraries.places.api.net.PlacesClient
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -104,4 +110,24 @@ object LocationModule {
   ): FusedLocationProviderClient {
     return LocationServices.getFusedLocationProviderClient(context)
   }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PlacesModule {
+
+  @Provides
+  fun providePlacesClient(@ApplicationContext context: Context): PlacesClient {
+    return Places.createClient(context)
+  }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class PlacesSearchRepositoryModule {
+
+  @Binds
+  abstract fun bindPlacesSearchRepository(
+    placesSearchRepositoryClient: PlacesSearchRepositoryClient
+  ): PlacesSearchRepository
 }

--- a/app/src/main/java/com/android/unio/model/hilt/module/HiltModule.kt
+++ b/app/src/main/java/com/android/unio/model/hilt/module/HiltModule.kt
@@ -1,8 +1,6 @@
 package com.android.unio.model.hilt.module
 
 import android.content.Context
-import android.content.pm.PackageManager
-import com.android.unio.BuildConfig
 import com.android.unio.model.association.AssociationRepository
 import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.event.EventRepository
@@ -128,6 +126,6 @@ abstract class PlacesSearchRepositoryModule {
 
   @Binds
   abstract fun bindPlacesSearchRepository(
-    placesSearchRepositoryClient: PlacesSearchRepositoryClient
+      placesSearchRepositoryClient: PlacesSearchRepositoryClient
   ): PlacesSearchRepository
 }

--- a/app/src/main/java/com/android/unio/model/map/Location.kt
+++ b/app/src/main/java/com/android/unio/model/map/Location.kt
@@ -1,3 +1,9 @@
 package com.android.unio.model.map
 
-data class Location(val placeId: String = "", val name: String = "", val address: String = "", val latitude: Double = 0.0, val longitude: Double = 0.0)
+data class Location(
+    val placeId: String = "",
+    val name: String = "",
+    val address: String = "",
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0
+)

--- a/app/src/main/java/com/android/unio/model/map/Location.kt
+++ b/app/src/main/java/com/android/unio/model/map/Location.kt
@@ -1,3 +1,3 @@
 package com.android.unio.model.map
 
-data class Location(val latitude: Double = 0.0, val longitude: Double = 0.0, val name: String = "")
+data class Location(val placeId: String = "", val name: String = "", val address: String = "", val latitude: Double = 0.0, val longitude: Double = 0.0)

--- a/app/src/main/java/com/android/unio/model/map/PlacesSearchRepository.kt
+++ b/app/src/main/java/com/android/unio/model/map/PlacesSearchRepository.kt
@@ -3,6 +3,11 @@ package com.android.unio.model.map
 import com.google.android.libraries.places.api.model.AutocompletePrediction
 
 interface PlacesSearchRepository {
-    fun searchPlaces(query: String, onResult: (List<AutocompletePrediction>) -> Unit, onError: (String) -> Unit)
-    fun fetchPlaceDetails(placeId: String, onResult: (Location) -> Unit, onError: (String) -> Unit)
+  fun searchPlaces(
+      query: String,
+      onResult: (List<AutocompletePrediction>) -> Unit,
+      onError: (String) -> Unit
+  )
+
+  fun fetchPlaceDetails(placeId: String, onResult: (Location) -> Unit, onError: (String) -> Unit)
 }

--- a/app/src/main/java/com/android/unio/model/map/PlacesSearchRepository.kt
+++ b/app/src/main/java/com/android/unio/model/map/PlacesSearchRepository.kt
@@ -1,0 +1,8 @@
+package com.android.unio.model.map
+
+import com.google.android.libraries.places.api.model.AutocompletePrediction
+
+interface PlacesSearchRepository {
+    fun searchPlaces(query: String, onResult: (List<AutocompletePrediction>) -> Unit, onError: (String) -> Unit)
+    fun fetchPlaceDetails(placeId: String, onResult: (Location) -> Unit, onError: (String) -> Unit)
+}

--- a/app/src/main/java/com/android/unio/model/map/PlacesSearchRepositoryClient.kt
+++ b/app/src/main/java/com/android/unio/model/map/PlacesSearchRepositoryClient.kt
@@ -8,52 +8,57 @@ import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRe
 import com.google.android.libraries.places.api.net.PlacesClient
 import javax.inject.Inject
 
-class PlacesSearchRepositoryClient
-@Inject constructor(private val placesClient: PlacesClient) : PlacesSearchRepository {
+class PlacesSearchRepositoryClient @Inject constructor(private val placesClient: PlacesClient) :
+    PlacesSearchRepository {
 
-    override fun searchPlaces(
-        query: String,
-        onResult: (List<AutocompletePrediction>) -> Unit,
-        onError: (String) -> Unit
-    ) {
-        val request = FindAutocompletePredictionsRequest.builder()
-            .setQuery(query)
-            .build()
+  override fun searchPlaces(
+      query: String,
+      onResult: (List<AutocompletePrediction>) -> Unit,
+      onError: (String) -> Unit
+  ) {
+    val request = FindAutocompletePredictionsRequest.builder().setQuery(query).build()
 
-        placesClient.findAutocompletePredictions(request)
-            .addOnSuccessListener { response ->
-                onResult(response.autocompletePredictions)
-            }
-            .addOnFailureListener { exception ->
-                Log.e("PlacesSearchRepository", "Error: ${exception.localizedMessage}")
-                onError("Failed to fetch results.")
-            }
-    }
+    placesClient
+        .findAutocompletePredictions(request)
+        .addOnSuccessListener { response -> onResult(response.autocompletePredictions) }
+        .addOnFailureListener { exception ->
+          Log.e("PlacesSearchRepository", "Error: ${exception.localizedMessage}")
+          onError("Failed to fetch results.")
+        }
+  }
 
-    // Fetch full place details (including coordinates) using the placeId
-    override fun fetchPlaceDetails(
-        placeId: String,
-        onResult: (Location) -> Unit,
-        onError: (String) -> Unit
-    ) {
-        val placeFields = listOf(Place.Field.ID, Place.Field.DISPLAY_NAME, Place.Field.DISPLAY_NAME, Place.Field.LOCATION)
-        val request = FetchPlaceRequest.newInstance(placeId, placeFields)
+  // Fetch full place details (including coordinates) using the placeId
+  override fun fetchPlaceDetails(
+      placeId: String,
+      onResult: (Location) -> Unit,
+      onError: (String) -> Unit
+  ) {
+    val placeFields =
+        listOf(
+            Place.Field.ID,
+            Place.Field.DISPLAY_NAME,
+            Place.Field.DISPLAY_NAME,
+            Place.Field.LOCATION)
+    val request = FetchPlaceRequest.newInstance(placeId, placeFields)
 
-        placesClient.fetchPlace(request)
-            .addOnSuccessListener { response ->
-                val place = response.place
-                val location = Location(
-                    placeId = place.id ?: "",
-                    name = place.displayName ?: "",
-                    address = place.formattedAddress ?: "",
-                    latitude = place.location?.latitude ?: 0.0,
-                    longitude = place.location?.longitude ?: 0.0
-                )
-                onResult(location)
-            }
-            .addOnFailureListener { exception ->
-                Log.e("PlacesSearchRepository", "Error fetching place details: ${exception.localizedMessage}")
-                onError("Failed to fetch place details.")
-            }
-    }
+    placesClient
+        .fetchPlace(request)
+        .addOnSuccessListener { response ->
+          val place = response.place
+          val location =
+              Location(
+                  placeId = place.id ?: "",
+                  name = place.displayName ?: "",
+                  address = place.formattedAddress ?: "",
+                  latitude = place.location?.latitude ?: 0.0,
+                  longitude = place.location?.longitude ?: 0.0)
+          onResult(location)
+        }
+        .addOnFailureListener { exception ->
+          Log.e(
+              "PlacesSearchRepository",
+              "Error fetching place details: ${exception.localizedMessage}")
+          onError("Failed to fetch place details.")
+        }
+  }
 }

--- a/app/src/main/java/com/android/unio/model/map/PlacesSearchRepositoryClient.kt
+++ b/app/src/main/java/com/android/unio/model/map/PlacesSearchRepositoryClient.kt
@@ -1,0 +1,59 @@
+package com.android.unio.model.map
+
+import android.util.Log
+import com.google.android.libraries.places.api.model.AutocompletePrediction
+import com.google.android.libraries.places.api.model.Place
+import com.google.android.libraries.places.api.net.FetchPlaceRequest
+import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
+import com.google.android.libraries.places.api.net.PlacesClient
+import javax.inject.Inject
+
+class PlacesSearchRepositoryClient
+@Inject constructor(private val placesClient: PlacesClient) : PlacesSearchRepository {
+
+    override fun searchPlaces(
+        query: String,
+        onResult: (List<AutocompletePrediction>) -> Unit,
+        onError: (String) -> Unit
+    ) {
+        val request = FindAutocompletePredictionsRequest.builder()
+            .setQuery(query)
+            .build()
+
+        placesClient.findAutocompletePredictions(request)
+            .addOnSuccessListener { response ->
+                onResult(response.autocompletePredictions)
+            }
+            .addOnFailureListener { exception ->
+                Log.e("PlacesSearchRepository", "Error: ${exception.localizedMessage}")
+                onError("Failed to fetch results.")
+            }
+    }
+
+    // Fetch full place details (including coordinates) using the placeId
+    override fun fetchPlaceDetails(
+        placeId: String,
+        onResult: (Location) -> Unit,
+        onError: (String) -> Unit
+    ) {
+        val placeFields = listOf(Place.Field.ID, Place.Field.DISPLAY_NAME, Place.Field.DISPLAY_NAME, Place.Field.LOCATION)
+        val request = FetchPlaceRequest.newInstance(placeId, placeFields)
+
+        placesClient.fetchPlace(request)
+            .addOnSuccessListener { response ->
+                val place = response.place
+                val location = Location(
+                    placeId = place.id ?: "",
+                    name = place.displayName ?: "",
+                    address = place.formattedAddress ?: "",
+                    latitude = place.location?.latitude ?: 0.0,
+                    longitude = place.location?.longitude ?: 0.0
+                )
+                onResult(location)
+            }
+            .addOnFailureListener { exception ->
+                Log.e("PlacesSearchRepository", "Error fetching place details: ${exception.localizedMessage}")
+                onError("Failed to fetch place details.")
+            }
+    }
+}

--- a/app/src/main/java/com/android/unio/model/map/PlacesSearchViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/map/PlacesSearchViewModel.kt
@@ -5,54 +5,50 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.libraries.places.api.model.AutocompletePrediction
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
-class PlacesSearchViewModel
-@Inject
-constructor(private val repository: PlacesSearchRepository) : ViewModel() {
+class PlacesSearchViewModel @Inject constructor(private val repository: PlacesSearchRepository) :
+    ViewModel() {
 
-    private val locationSuggestions_ = MutableStateFlow<List<AutocompletePrediction>>(emptyList())
-    val locationSuggestions: StateFlow<List<AutocompletePrediction>> = locationSuggestions_.asStateFlow()
+  private val locationSuggestions_ = MutableStateFlow<List<AutocompletePrediction>>(emptyList())
+  val locationSuggestions: StateFlow<List<AutocompletePrediction>> =
+      locationSuggestions_.asStateFlow()
 
-    private val query_ = MutableStateFlow("")
-    val query: StateFlow<String> = query_.asStateFlow()
+  private val query_ = MutableStateFlow("")
+  val query: StateFlow<String> = query_.asStateFlow()
 
-    private val selectedLocation_ = MutableStateFlow<Location?>(null)
-    val selectedLocation: StateFlow<Location?> = selectedLocation_.asStateFlow()
+  private val selectedLocation_ = MutableStateFlow<Location?>(null)
+  val selectedLocation: StateFlow<Location?> = selectedLocation_.asStateFlow()
 
-    init {
-        viewModelScope.launch {
-            query_
-                .filter { it.isNotEmpty() }
-                .collectLatest { query ->
-                    Log.e("PlacesSearchViewModel", "Searching for $query")
-                    repository.searchPlaces(
-                        query,
-                        onResult = { predictions ->
-                            locationSuggestions_.value = predictions
-                        },
-                        onError = { Log.e("PlacesSearchViewModel", "Error fetching places.") }
-                    )
-                }
-        }
+  init {
+    viewModelScope.launch {
+      query_
+          .filter { it.isNotEmpty() }
+          .collectLatest { query ->
+            Log.e("PlacesSearchViewModel", "Searching for $query")
+            repository.searchPlaces(
+                query,
+                onResult = { predictions -> locationSuggestions_.value = predictions },
+                onError = { Log.e("PlacesSearchViewModel", "Error fetching places.") })
+          }
     }
+  }
 
-    fun setQuery(query: String) {
-        query_.value = query
-    }
+  fun setQuery(query: String) {
+    query_.value = query
+  }
 
-    fun selectLocation(prediction: AutocompletePrediction) {
-        repository.fetchPlaceDetails(prediction.placeId, { locationWithCoordinates ->
-            selectedLocation_.value = locationWithCoordinates
-        }, { error ->
-            Log.e("PlacesSearchViewModel", "Error fetching place details: $error")
-        })
-    }
+  fun selectLocation(prediction: AutocompletePrediction) {
+    repository.fetchPlaceDetails(
+        prediction.placeId,
+        { locationWithCoordinates -> selectedLocation_.value = locationWithCoordinates },
+        { error -> Log.e("PlacesSearchViewModel", "Error fetching place details: $error") })
+  }
 }

--- a/app/src/main/java/com/android/unio/model/map/PlacesSearchViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/map/PlacesSearchViewModel.kt
@@ -1,0 +1,58 @@
+package com.android.unio.model.map
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.libraries.places.api.model.AutocompletePrediction
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PlacesSearchViewModel
+@Inject
+constructor(private val repository: PlacesSearchRepository) : ViewModel() {
+
+    private val locationSuggestions_ = MutableStateFlow<List<AutocompletePrediction>>(emptyList())
+    val locationSuggestions: StateFlow<List<AutocompletePrediction>> = locationSuggestions_.asStateFlow()
+
+    private val query_ = MutableStateFlow("")
+    val query: StateFlow<String> = query_.asStateFlow()
+
+    private val selectedLocation_ = MutableStateFlow<Location?>(null)
+    val selectedLocation: StateFlow<Location?> = selectedLocation_.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            query_
+                .filter { it.isNotEmpty() }
+                .collectLatest { query ->
+                    Log.e("PlacesSearchViewModel", "Searching for $query")
+                    repository.searchPlaces(
+                        query,
+                        onResult = { predictions ->
+                            locationSuggestions_.value = predictions
+                        },
+                        onError = { Log.e("PlacesSearchViewModel", "Error fetching places.") }
+                    )
+                }
+        }
+    }
+
+    fun setQuery(query: String) {
+        query_.value = query
+    }
+
+    fun selectLocation(prediction: AutocompletePrediction) {
+        repository.fetchPlaceDetails(prediction.placeId, { locationWithCoordinates ->
+            selectedLocation_.value = locationWithCoordinates
+        }, { error ->
+            Log.e("PlacesSearchViewModel", "Error fetching place details: $error")
+        })
+    }
+}

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -32,7 +32,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Place
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DatePicker
@@ -117,9 +116,9 @@ fun EventCreationScreen(
 
   val eventBannerUri = remember { mutableStateOf<Uri>(Uri.EMPTY) }
 
-    var locationQuery by remember { mutableStateOf("") }
-    val locationSuggestions by placesSearchViewModel.locationSuggestions.collectAsState()
-    val selectedLocation by placesSearchViewModel.selectedLocation.collectAsState()
+  var locationQuery by remember { mutableStateOf("") }
+  val locationSuggestions by placesSearchViewModel.locationSuggestions.collectAsState()
+  val selectedLocation by placesSearchViewModel.selectedLocation.collectAsState()
 
   Scaffold(modifier = Modifier.testTag(EventCreationTestTags.SCREEN)) { padding ->
     Column(
@@ -218,32 +217,28 @@ fun EventCreationScreen(
               modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.LOCATION),
               value = locationQuery,
               onValueChange = {
-                  locationQuery = it
-                  placesSearchViewModel.setQuery(it)
+                locationQuery = it
+                placesSearchViewModel.setQuery(it)
               },
               label = { Text(context.getString(R.string.event_creation_location_label)) },
-              leadingIcon =  {
-                  Icon(Icons.Default.Place, contentDescription = "Search for location")
-              }
-          )
+              leadingIcon = {
+                Icon(Icons.Default.Place, contentDescription = "Search for location")
+              })
 
-        if (locationQuery.isNotEmpty() && selectedLocation != null) {
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(8.dp)
-            ) {
-                locationSuggestions.forEach { prediction ->
-                    Text(
-                        text = prediction.getPrimaryText(null).toString(),
-                        modifier = Modifier
-                            .clickable {
-                                placesSearchViewModel.selectLocation(prediction)
-                                locationQuery = prediction.getSecondaryText(null).toString()
+          if (locationQuery.isNotEmpty() && selectedLocation != null) {
+            Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+              locationSuggestions.forEach { prediction ->
+                Text(
+                    text = prediction.getPrimaryText(null).toString(),
+                    modifier =
+                        Modifier.clickable {
+                              placesSearchViewModel.selectLocation(prediction)
+                              locationQuery = prediction.getSecondaryText(null).toString()
                             }
-                            .padding(8.dp)
-                    )
-                }
+                            .padding(8.dp))
+              }
             }
-        }
+          }
 
           Spacer(modifier = Modifier.width(10.dp))
 

--- a/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
@@ -113,7 +113,7 @@ class SearchRepositoryTest {
           description = "Plus grand festival du monde (non contractuel)",
           price = 40.5,
           startDate = Timestamp(GregorianCalendar(2004, 7, 1).time),
-          location = Location(latitude = 1.2345, longitude =  2.3455, name = "Somewhere"),
+          location = Location(latitude = 1.2345, longitude = 2.3455, name = "Somewhere"),
           placesRemaining = -1)
   private val event2 =
       Event(
@@ -125,7 +125,7 @@ class SearchRepositoryTest {
           description = "Plus grand festival du monde (non contractuel)",
           price = 40.5,
           startDate = Timestamp(GregorianCalendar(2008, 7, 1).time),
-          location = Location(latitude = 1.2345, longitude =  2.3455, name =  "Somewhere"),
+          location = Location(latitude = 1.2345, longitude = 2.3455, name = "Somewhere"),
           placesRemaining = -1)
 
   @Before

--- a/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
@@ -113,7 +113,7 @@ class SearchRepositoryTest {
           description = "Plus grand festival du monde (non contractuel)",
           price = 40.5,
           startDate = Timestamp(GregorianCalendar(2004, 7, 1).time),
-          location = Location(1.2345, 2.3455, "Somewhere"),
+          location = Location(latitude = 1.2345, longitude =  2.3455, name = "Somewhere"),
           placesRemaining = -1)
   private val event2 =
       Event(
@@ -125,7 +125,7 @@ class SearchRepositoryTest {
           description = "Plus grand festival du monde (non contractuel)",
           price = 40.5,
           startDate = Timestamp(GregorianCalendar(2008, 7, 1).time),
-          location = Location(1.2345, 2.3455, "Somewhere"),
+          location = Location(latitude = 1.2345, longitude =  2.3455, name =  "Somewhere"),
           placesRemaining = -1)
 
   @Before

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,6 +102,7 @@ composeMaterial = "1.4.0"
 core = "1.46.0"
 firebaseFunctionsKtx = "21.0.0"
 playServicesLocation = "21.3.0"
+places = "4.1.0"
 
 
 [libraries]
@@ -204,6 +205,7 @@ androidx-compose-material = { group = "androidx.wear.compose", name = "compose-m
 core = { group = "com.google.ar", name = "core", version.ref = "core" }
 firebase-functions-ktx = { group = "com.google.firebase", name = "firebase-functions-ktx", version.ref = "firebaseFunctionsKtx" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+places = { group = "com.google.android.libraries.places", name = "places", version.ref = "places" }
 
 
 


### PR DESCRIPTION
## ⚠️ This PR will be abandoned (or not entirely at least)
Problem: Unfortunately, I have found no way of bypassing the requirement of a billing address in the Google cloud services, so this PR will most likely be abandoned. Because of this, I unfortunately cannot see the results of my work, only that it makes the queries to the Places Search API, but the response never returns predictions, only the error message saying that a billing address is required.

## Instead 
We have to turn to a completely free (and hassle-free) solution. In the bootcamp, we had used `Nominatim`, but I think it is a poor library, at least, compared to other solutions. After some research, I have found that people prefer the solution of `mapbox`'s [Search box API](https://docs.mapbox.com/api/search/search-box/). Try playing around with their [playground example](https://docs.mapbox.com/playground/search-box/). It shows it can fetch really nice informations about locations, and that we can essentially reproduce something similar to the average map apps out there and easy to the eye.

## Description

This PR is an attempt at implementing the integration of the Google Places API into the `Event` creation screen. It allows users to search for and select a location using the Places Autocomplete API. The search bar is essentially similar to the search bar in the Googles Maps app. The location suggestions are fetched as the user types in the location outlined text field and allows them to select a place from a dropdown, filling the location with the place’s name and address.

## Motivation and Context

By integrating the Google Places API, we enable users to search and select a location using the Autocomplete feature, to make Location selection very easy and similar to what most people are used to, e.g. Google Maps. 

### PlacesSearchViewModel:
- Added logic to query the Places API for location suggestions as the user types in the search field.
- The query is sent to the repository, which returns a list of autocomplete predictions (locations).
- When a user selects a prediction, more data about it is fetched and the actual Location object is built.

### PlacesSearchRepository:
- Used the PlacesClient to query for autocomplete predictions based on the user’s search query.
- Fetches information (name, address and coordinates) of a selected place using its Place ID, and builds a `Location` object.

### EventCreationScreen:
- The location field displays a list of autocomplete suggestions as the user types.
- Integrated the PlacesSearchViewModel to handle fetching of location suggestions.