### PR TITLE
Adapt the "following" feature to work in offline mode

### DIFF
--- a/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
@@ -258,27 +258,27 @@ class AssociationProfileTest : TearDown() {
     assert(associationViewModel.selectedAssociation.value!!.followersCount == currentCount)
   }
 
-    @Test
-    fun testFollowOffline() {
-        val context: Context = ApplicationProvider.getApplicationContext()
-        composeTestRule.setContent {
-            AssociationProfileScaffold(
-                navigationAction, userViewModel, eventViewModel, associationViewModel) {}
-        }
-        
-        val currentCount = associationViewModel.selectedAssociation.value!!.followersCount
-
-        composeTestRule
-            .onNodeWithTag(AssociationProfileTestTags.FOLLOW_BUTTON)
-            .assertDisplayComponentInScroll()
-        composeTestRule
-            .onNodeWithText(context.getString(R.string.association_follow))
-            .assertIsDisplayed()
-
-        composeTestRule.onNodeWithTag(AssociationProfileTestTags.FOLLOW_BUTTON).performClick()
-        assert(!userViewModel.user.value?.followedAssociations!!.contains(associations.first().uid))
-        assert(associationViewModel.selectedAssociation.value!!.followersCount == currentCount)
+  @Test
+  fun testFollowOffline() {
+    val context: Context = ApplicationProvider.getApplicationContext()
+    composeTestRule.setContent {
+      AssociationProfileScaffold(
+          navigationAction, userViewModel, eventViewModel, associationViewModel) {}
     }
+
+    val currentCount = associationViewModel.selectedAssociation.value!!.followersCount
+
+    composeTestRule
+        .onNodeWithTag(AssociationProfileTestTags.FOLLOW_BUTTON)
+        .assertDisplayComponentInScroll()
+    composeTestRule
+        .onNodeWithText(context.getString(R.string.association_follow))
+        .assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag(AssociationProfileTestTags.FOLLOW_BUTTON).performClick()
+    assert(!userViewModel.user.value?.followedAssociations!!.contains(associations.first().uid))
+    assert(associationViewModel.selectedAssociation.value!!.followersCount == currentCount)
+  }
 
   @Test
   fun testButtonBehavior() {
@@ -305,7 +305,6 @@ class AssociationProfileTest : TearDown() {
     composeTestRule.onNodeWithTag(AssociationProfileTestTags.DESIGNER_ROLES).performClick()
     assertSnackBarIsDisplayed()
   }
-
 
   private fun assertSnackBarIsDisplayed() {
     composeTestRule.onNodeWithTag(AssociationProfileTestTags.SNACKBAR_HOST).assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
@@ -1,12 +1,16 @@
 package com.android.unio.components.association
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.getSystemService
 import androidx.navigation.NavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.android.unio.R
@@ -79,6 +83,8 @@ class AssociationProfileTest : TearDown() {
   @MockK private lateinit var userRepository: UserRepositoryFirestore
   @MockK private lateinit var imageRepository: ImageRepositoryFirebaseStorage
 
+  @MockK private lateinit var connectivityManager: ConnectivityManager
+
   @get:Rule val composeTestRule = createComposeRule()
 
   @get:Rule val hiltRule = HiltAndroidRule(this)
@@ -89,11 +95,14 @@ class AssociationProfileTest : TearDown() {
     hiltRule.inject()
 
     mockkStatic(FirebaseFirestore::class)
+    mockkStatic(Network::class)
+    mockkStatic(ContextCompat::class)
     val db = mockk<FirebaseFirestore>()
     val collection = mockk<CollectionReference>()
     val query = mockk<Query>()
     val task = mock<Task<QuerySnapshot>>()
 
+    every { getSystemService(any(), ConnectivityManager::class.java) } returns connectivityManager
     every { Firebase.firestore } returns db
     every { db.collection(any()) } returns collection
     every { collection.whereIn(any(FieldPath::class), any()) } returns query
@@ -180,6 +189,8 @@ class AssociationProfileTest : TearDown() {
 
   @Test
   fun testAssociationProfileDisplayComponent() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule.setContent {
       AssociationProfileScaffold(
           navigationAction, userViewModel, eventViewModel, associationViewModel) {}
@@ -227,6 +238,8 @@ class AssociationProfileTest : TearDown() {
 
   @Test
   fun testFollowAssociation() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     val context: Context = ApplicationProvider.getApplicationContext()
     composeTestRule.setContent {
       AssociationProfileScaffold(
@@ -261,10 +274,12 @@ class AssociationProfileTest : TearDown() {
   @Test
   fun testFollowOffline() {
     val context: Context = ApplicationProvider.getApplicationContext()
+    every { connectivityManager?.activeNetwork } returns null
     composeTestRule.setContent {
       AssociationProfileScaffold(
           navigationAction, userViewModel, eventViewModel, associationViewModel) {}
     }
+    // Disable internet connction in the test
 
     val currentCount = associationViewModel.selectedAssociation.value!!.followersCount
 
@@ -282,6 +297,8 @@ class AssociationProfileTest : TearDown() {
 
   @Test
   fun testButtonBehavior() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule.setContent {
       AssociationProfileScaffold(
           navigationAction, userViewModel, eventViewModel, associationViewModel) {}
@@ -314,6 +331,8 @@ class AssociationProfileTest : TearDown() {
 
   @Test
   fun testGoBackButton() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule.setContent {
       AssociationProfileScaffold(
           navigationAction, userViewModel, eventViewModel, associationViewModel) {}
@@ -328,6 +347,8 @@ class AssociationProfileTest : TearDown() {
 
   @Test
   fun testAssociationProfileGoodId() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule.setContent {
       AssociationProfileScaffold(
           navigationAction, userViewModel, eventViewModel, associationViewModel) {}
@@ -339,6 +360,8 @@ class AssociationProfileTest : TearDown() {
 
   @Test
   fun testAssociationProfileNoId() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     associationViewModel.selectAssociation("3")
     composeTestRule.setContent {
       AssociationProfileScreen(

--- a/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
@@ -258,6 +258,28 @@ class AssociationProfileTest : TearDown() {
     assert(associationViewModel.selectedAssociation.value!!.followersCount == currentCount)
   }
 
+    @Test
+    fun testFollowOffline() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        composeTestRule.setContent {
+            AssociationProfileScaffold(
+                navigationAction, userViewModel, eventViewModel, associationViewModel) {}
+        }
+        
+        val currentCount = associationViewModel.selectedAssociation.value!!.followersCount
+
+        composeTestRule
+            .onNodeWithTag(AssociationProfileTestTags.FOLLOW_BUTTON)
+            .assertDisplayComponentInScroll()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.association_follow))
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(AssociationProfileTestTags.FOLLOW_BUTTON).performClick()
+        assert(!userViewModel.user.value?.followedAssociations!!.contains(associations.first().uid))
+        assert(associationViewModel.selectedAssociation.value!!.followersCount == currentCount)
+    }
+
   @Test
   fun testButtonBehavior() {
     composeTestRule.setContent {
@@ -283,6 +305,7 @@ class AssociationProfileTest : TearDown() {
     composeTestRule.onNodeWithTag(AssociationProfileTestTags.DESIGNER_ROLES).performClick()
     assertSnackBarIsDisplayed()
   }
+
 
   private fun assertSnackBarIsDisplayed() {
     composeTestRule.onNodeWithTag(AssociationProfileTestTags.SNACKBAR_HOST).assertIsDisplayed()

--- a/app/src/main/java/com/android/unio/model/follow/ConcurrentAssociationUserRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/follow/ConcurrentAssociationUserRepositoryFirestore.kt
@@ -1,6 +1,5 @@
 package com.android.unio.model.follow
 
-import android.util.Log
 import com.android.unio.model.association.Association
 import com.android.unio.model.association.AssociationRepository
 import com.android.unio.model.association.AssociationRepositoryFirestore
@@ -43,11 +42,7 @@ constructor(
           batch.set(associationRef, AssociationRepositoryFirestore.serialize(association))
           batch.set(userRef, UserRepositoryFirestore.serialize(user))
         }
-        .addOnSuccessListener {
-          onSuccess()
-        }
-        .addOnFailureListener {
-          onFailure(it)
-        }
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { onFailure(it) }
   }
 }

--- a/app/src/main/java/com/android/unio/model/follow/ConcurrentAssociationUserRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/follow/ConcurrentAssociationUserRepositoryFirestore.kt
@@ -1,5 +1,6 @@
 package com.android.unio.model.follow
 
+import android.util.Log
 import com.android.unio.model.association.Association
 import com.android.unio.model.association.AssociationRepository
 import com.android.unio.model.association.AssociationRepositoryFirestore
@@ -41,8 +42,13 @@ constructor(
 
           batch.set(associationRef, AssociationRepositoryFirestore.serialize(association))
           batch.set(userRef, UserRepositoryFirestore.serialize(user))
+        Log.d("ConcurrentAssociationUserRepositoryFirestore", "updateFollow: walked through ${user.firstName} ${association.name}")
         }
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { onFailure(it) }
+        .addOnSuccessListener {
+            Log.d("ConcurrentAssociationUserRepositoryFirestore", "updateFollow: success")
+            onSuccess() }
+        .addOnFailureListener {
+            Log.e("ConcurrentAssociationUserRepositoryFirestore", "updateFollow: failed")
+            onFailure(it) }
   }
 }

--- a/app/src/main/java/com/android/unio/model/follow/ConcurrentAssociationUserRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/follow/ConcurrentAssociationUserRepositoryFirestore.kt
@@ -42,13 +42,12 @@ constructor(
 
           batch.set(associationRef, AssociationRepositoryFirestore.serialize(association))
           batch.set(userRef, UserRepositoryFirestore.serialize(user))
-        Log.d("ConcurrentAssociationUserRepositoryFirestore", "updateFollow: walked through ${user.firstName} ${association.name}")
         }
         .addOnSuccessListener {
-            Log.d("ConcurrentAssociationUserRepositoryFirestore", "updateFollow: success")
-            onSuccess() }
+          onSuccess()
+        }
         .addOnFailureListener {
-            Log.e("ConcurrentAssociationUserRepositoryFirestore", "updateFollow: failed")
-            onFailure(it) }
+          onFailure(it)
+        }
   }
 }

--- a/app/src/main/java/com/android/unio/model/utils/Utils.kt
+++ b/app/src/main/java/com/android/unio/model/utils/Utils.kt
@@ -1,0 +1,13 @@
+package com.android.unio.model.utils
+
+import android.content.Context
+import android.net.ConnectivityManager
+import androidx.core.content.ContextCompat.getSystemService
+
+object Utils {
+
+  fun checkInternetConnection(context: Context): Boolean {
+    val connectivityManager = getSystemService(context, ConnectivityManager::class.java)
+    return connectivityManager?.activeNetwork != null
+  }
+}

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -66,6 +66,7 @@ import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.strings.test_tags.AssociationProfileTestTags
 import com.android.unio.model.user.User
 import com.android.unio.model.user.UserViewModel
+import com.android.unio.model.utils.Utils
 import com.android.unio.ui.event.EventCard
 import com.android.unio.ui.image.AsyncImageWrapper
 import com.android.unio.ui.navigation.NavigationAction
@@ -559,26 +560,32 @@ private fun AssociationHeader(
           style = AppTypography.headlineSmall,
           modifier =
               Modifier.padding(bottom = 14.dp).testTag(AssociationProfileTestTags.HEADER_MEMBERS))
-      if (isFollowed) {
-        OutlinedButton(
-            enabled = enableButton,
-            onClick = onFollow,
-            modifier = Modifier.testTag(AssociationProfileTestTags.FOLLOW_BUTTON)) {
-              Text(context.getString(R.string.association_unfollow))
+        val isConnected = Utils.checkInternetConnection(context)
+        if(isConnected){
+            if (isFollowed) {
+                OutlinedButton(
+                    enabled = enableButton,
+                    onClick = onFollow,
+                    modifier = Modifier.testTag(AssociationProfileTestTags.FOLLOW_BUTTON)) {
+                    Text(context.getString(R.string.association_unfollow))
+                }
+            } else {
+                Button(
+                    enabled = enableButton,
+                    onClick = onFollow,
+                    modifier = Modifier.testTag(AssociationProfileTestTags.FOLLOW_BUTTON)) {
+                    Icon(
+                        Icons.Filled.Add,
+                        contentDescription =
+                        context.getString(R.string.association_content_description_follow_icon))
+                    Spacer(Modifier.width(2.dp))
+                    Text(context.getString(R.string.association_follow))
+                }
             }
-      } else {
-        Button(
-            enabled = enableButton,
-            onClick = onFollow,
-            modifier = Modifier.testTag(AssociationProfileTestTags.FOLLOW_BUTTON)) {
-              Icon(
-                  Icons.Filled.Add,
-                  contentDescription =
-                      context.getString(R.string.association_content_description_follow_icon))
-              Spacer(Modifier.width(2.dp))
-              Text(context.getString(R.string.association_follow))
-            }
-      }
+        } else {
+            Toast.makeText(context, context.getString(R.string.no_internet_connection), Toast.LENGTH_SHORT).show()
+        }
+
     }
   }
 }

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -287,6 +287,7 @@ private fun AssociationProfileContent(
 
   val onFollow = {
     if (isConnected) {
+      Log.d("AssociationProfileContent", "Follow button clicked.")
       enableButton = false
       associationViewModel.updateFollow(association!!, user!!, isFollowed) {
         userViewModel.refreshUser()
@@ -294,6 +295,7 @@ private fun AssociationProfileContent(
       }
       isFollowed = !isFollowed
     } else {
+      Log.d("AssociationProfileContent", "No internet connection.")
       Toast.makeText(
               context, context.getString(R.string.no_internet_connection), Toast.LENGTH_SHORT)
           .show()

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -287,7 +287,6 @@ private fun AssociationProfileContent(
 
   val onFollow = {
     if (isConnected) {
-      Log.d("AssociationProfileContent", "Follow button clicked.")
       enableButton = false
       associationViewModel.updateFollow(association!!, user!!, isFollowed) {
         userViewModel.refreshUser()
@@ -295,7 +294,6 @@ private fun AssociationProfileContent(
       }
       isFollowed = !isFollowed
     } else {
-      Log.d("AssociationProfileContent", "No internet connection.")
       Toast.makeText(
               context, context.getString(R.string.no_internet_connection), Toast.LENGTH_SHORT)
           .show()

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -268,6 +268,7 @@ private fun AssociationProfileContent(
     eventViewModel: EventViewModel,
     associationViewModel: AssociationViewModel
 ) {
+  val context = LocalContext.current
   val association by associationViewModel.selectedAssociation.collectAsState()
   val user by userViewModel.user.collectAsState()
 
@@ -282,13 +283,21 @@ private fun AssociationProfileContent(
     mutableStateOf(user!!.followedAssociations.contains(association!!.uid))
   }
   var enableButton by remember { mutableStateOf(true) }
+  val isConnected = Utils.checkInternetConnection(context)
+
   val onFollow = {
-    enableButton = false
-    associationViewModel.updateFollow(association!!, user!!, isFollowed) {
-      userViewModel.refreshUser()
-      enableButton = true
+    if (isConnected) {
+      enableButton = false
+      associationViewModel.updateFollow(association!!, user!!, isFollowed) {
+        userViewModel.refreshUser()
+        enableButton = true
+      }
+      isFollowed = !isFollowed
+    } else {
+      Toast.makeText(
+              context, context.getString(R.string.no_internet_connection), Toast.LENGTH_SHORT)
+          .show()
     }
-    isFollowed = !isFollowed
   }
 
   val onMemberClick = { member: User ->
@@ -560,32 +569,27 @@ private fun AssociationHeader(
           style = AppTypography.headlineSmall,
           modifier =
               Modifier.padding(bottom = 14.dp).testTag(AssociationProfileTestTags.HEADER_MEMBERS))
-        val isConnected = Utils.checkInternetConnection(context)
-        if(isConnected){
-            if (isFollowed) {
-                OutlinedButton(
-                    enabled = enableButton,
-                    onClick = onFollow,
-                    modifier = Modifier.testTag(AssociationProfileTestTags.FOLLOW_BUTTON)) {
-                    Text(context.getString(R.string.association_unfollow))
-                }
-            } else {
-                Button(
-                    enabled = enableButton,
-                    onClick = onFollow,
-                    modifier = Modifier.testTag(AssociationProfileTestTags.FOLLOW_BUTTON)) {
-                    Icon(
-                        Icons.Filled.Add,
-                        contentDescription =
-                        context.getString(R.string.association_content_description_follow_icon))
-                    Spacer(Modifier.width(2.dp))
-                    Text(context.getString(R.string.association_follow))
-                }
-            }
-        } else {
-            Toast.makeText(context, context.getString(R.string.no_internet_connection), Toast.LENGTH_SHORT).show()
-        }
 
+      if (isFollowed) {
+        OutlinedButton(
+            enabled = enableButton,
+            onClick = onFollow,
+            modifier = Modifier.testTag(AssociationProfileTestTags.FOLLOW_BUTTON)) {
+              Text(context.getString(R.string.association_unfollow))
+            }
+      } else {
+        Button(
+            enabled = enableButton,
+            onClick = onFollow,
+            modifier = Modifier.testTag(AssociationProfileTestTags.FOLLOW_BUTTON)) {
+              Icon(
+                  Icons.Filled.Add,
+                  contentDescription =
+                      context.getString(R.string.association_content_description_follow_icon))
+              Spacer(Modifier.width(2.dp))
+              Text(context.getString(R.string.association_follow))
+            }
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
+++ b/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
@@ -56,190 +56,226 @@ import com.google.firebase.auth.auth
 
 @Composable
 fun WelcomeScreen(userViewModel: UserViewModel) {
-  val context = LocalContext.current
+    val context = LocalContext.current
 
-  var email by remember { mutableStateOf("") }
-  var password by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
 
-  var showPassword by remember { mutableStateOf(false) }
+    var showPassword by remember { mutableStateOf(false) }
 
-  val validEmail = isValidEmail(email)
-  val validPassword = isValidPassword(password)
-  val enabled = validEmail && validPassword
+    val validEmail = isValidEmail(email)
+    val validPassword = isValidPassword(password)
+    val enabled = validEmail && validPassword
 
-  val passwordError = !validPassword && password.isNotEmpty()
+    val passwordError = !validPassword && password.isNotEmpty()
 
-  Scaffold(
-      modifier = Modifier.testTag(WelcomeTestTags.SCREEN).fillMaxSize(),
-      content = { padding ->
-        Column(
-            modifier = Modifier.padding(padding).fillMaxSize(),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally) {
-              Box(modifier = Modifier.clip(CircleShape).size(150.dp).background(Color.Gray))
-              Spacer(modifier = Modifier.size(20.dp))
+    Scaffold(
+        modifier = Modifier
+            .testTag(WelcomeTestTags.SCREEN)
+            .fillMaxSize(),
+        content = { padding ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(modifier = Modifier
+                    .clip(CircleShape)
+                    .size(150.dp)
+                    .background(Color.Gray))
+                Spacer(modifier = Modifier.size(20.dp))
 
-              Text(
-                  context.getString(R.string.welcome_message),
-                  style = AppTypography.titleLarge,
-                  modifier = Modifier.fillMaxWidth(0.8f),
-                  textAlign = Center)
+                Text(
+                    context.getString(R.string.welcome_message),
+                    style = AppTypography.titleLarge,
+                    modifier = Modifier.fillMaxWidth(0.8f),
+                    textAlign = Center
+                )
 
-              Spacer(modifier = Modifier.size(50.dp))
-              Text(
-                  context.getString(R.string.welcome_login_signup),
-                  style = AppTypography.titleMedium)
+                Spacer(modifier = Modifier.size(50.dp))
+                Text(
+                    context.getString(R.string.welcome_login_signup),
+                    style = AppTypography.titleMedium
+                )
 
-              OutlinedTextField(
-                  modifier = Modifier.testTag(WelcomeTestTags.EMAIL),
-                  value = email,
-                  onValueChange = { email = it },
-                  keyboardOptions =
-                      KeyboardOptions(
-                          keyboardType = KeyboardType.Email,
-                          imeAction = ImeAction.Done,
-                          capitalization = KeyboardCapitalization.None),
-                  singleLine = true,
-                  label = { Text(context.getString(R.string.welcome_email_enter)) },
-                  placeholder = { Text(context.getString(R.string.welcome_email_display)) },
-              )
+                OutlinedTextField(
+                    modifier = Modifier.testTag(WelcomeTestTags.EMAIL),
+                    value = email,
+                    onValueChange = { email = it },
+                    keyboardOptions =
+                    KeyboardOptions(
+                        keyboardType = KeyboardType.Email,
+                        imeAction = ImeAction.Done,
+                        capitalization = KeyboardCapitalization.None
+                    ),
+                    singleLine = true,
+                    label = { Text(context.getString(R.string.welcome_email_enter)) },
+                    placeholder = { Text(context.getString(R.string.welcome_email_display)) },
+                )
 
-              OutlinedTextField(
-                  modifier = Modifier.testTag(WelcomeTestTags.PASSWORD),
-                  value = password,
-                  onValueChange = { password = it },
-                  keyboardOptions =
-                      KeyboardOptions(
-                          keyboardType = KeyboardType.Password,
-                          imeAction = ImeAction.Done,
-                          capitalization = KeyboardCapitalization.None),
-                  singleLine = true,
-                  label = { Text(context.getString(R.string.welcome_password_enter)) },
-                  isError = passwordError,
-                  supportingText = {
-                    if (passwordError) {
-                      Text(context.getString(R.string.welcome_password_error_correction))
-                    }
-                  },
-                  trailingIcon = {
-                    IconButton(
-                        onClick = { showPassword = !showPassword },
-                    ) {
-                      Icon(
-                          if (showPassword) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
-                          contentDescription =
-                              if (showPassword)
-                                  context.getString(
-                                      R.string.welcome_content_description_hide_password)
-                              else
-                                  context.getString(
-                                      R.string.welcome_content_description_show_password),
-                      )
-                    }
-                  },
-                  visualTransformation =
-                      if (showPassword) VisualTransformation.None
-                      else PasswordVisualTransformation(),
-              )
+                OutlinedTextField(
+                    modifier = Modifier.testTag(WelcomeTestTags.PASSWORD),
+                    value = password,
+                    onValueChange = { password = it },
+                    keyboardOptions =
+                    KeyboardOptions(
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Done,
+                        capitalization = KeyboardCapitalization.None
+                    ),
+                    singleLine = true,
+                    label = { Text(context.getString(R.string.welcome_password_enter)) },
+                    isError = passwordError,
+                    supportingText = {
+                        if (passwordError) {
+                            Text(context.getString(R.string.welcome_password_error_correction))
+                        }
+                    },
+                    trailingIcon = {
+                        IconButton(
+                            onClick = { showPassword = !showPassword },
+                        ) {
+                            Icon(
+                                if (showPassword) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                                contentDescription =
+                                if (showPassword)
+                                    context.getString(
+                                        R.string.welcome_content_description_hide_password
+                                    )
+                                else
+                                    context.getString(
+                                        R.string.welcome_content_description_show_password
+                                    ),
+                            )
+                        }
+                    },
+                    visualTransformation =
+                    if (showPassword) VisualTransformation.None
+                    else PasswordVisualTransformation(),
+                )
 
-              Spacer(modifier = Modifier.size(70.dp))
+                Spacer(modifier = Modifier.size(70.dp))
 
-              Button(
-                  modifier = Modifier.testTag(WelcomeTestTags.BUTTON),
-                  onClick = {
-                    if (!enabled) {
-                      Toast.makeText(
-                              context,
-                              context.getString(R.string.welcome_malformed_email_password),
-                              Toast.LENGTH_SHORT)
-                          .show()
-                    } else {
-                      userViewModel.setCredential(EmailAuthProvider.getCredential(email, password))
-                      handleAuthentication(email, password, context)
-                    }
-                  },
-                  enabled = enabled) {
+                Button(
+                    modifier = Modifier.testTag(WelcomeTestTags.BUTTON),
+                    onClick = {
+                        if (!enabled) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.welcome_malformed_email_password),
+                                Toast.LENGTH_SHORT
+                            )
+                                .show()
+                        } else {
+                            userViewModel.setCredential(
+                                EmailAuthProvider.getCredential(
+                                    email,
+                                    password
+                                )
+                            )
+                            handleAuthentication(email, password, context)
+                        }
+                    },
+                    enabled = enabled
+                ) {
                     Text(context.getString(R.string.welcome_button_continue))
-                  }
+                }
             }
-      })
+        })
 }
 
 fun handleAuthentication(email: String, password: String, context: Context) {
 
-  // Check internet connectivity
-  val isConnected = checkInternetConnection(context)
-  if (!isConnected) {
-    Toast.makeText(context, "You appear to be offline.", Toast.LENGTH_SHORT).show()
-    return
-  }
-
-  signInOrCreateAccount(email, password, Firebase.auth) { signInResult ->
-    // NOTE: No need to navigate to other screens, that is already handled by the listener in
-    // MainActivity
-    when (signInResult.state) {
-      SignInState.INVALID_CREDENTIALS -> {
-        Toast.makeText(
-                context,
-                context.getString(R.string.welcome_toast_invalid_creds),
-                Toast.LENGTH_SHORT)
-            .show()
-      }
-      SignInState.INVALID_EMAIL_FORMAT -> {
-        Toast.makeText(
-                context,
-                context.getString(R.string.welcome_toast_enter_valid_email),
-                Toast.LENGTH_SHORT)
-            .show()
-      }
-      SignInState.SUCCESS_SIGN_IN -> {
-        Toast.makeText(
-                context, context.getString(R.string.welcome_toast_sign_in), Toast.LENGTH_SHORT)
-            .show()
-
-        if (signInResult.user?.isEmailVerified == false) {
-          signInResult.user.sendEmailVerification().addOnCompleteListener {
-            if (it.isSuccessful) {
-              Toast.makeText(
-                      context,
-                      context.getString(R.string.welcome_toast_verification_sent),
-                      Toast.LENGTH_SHORT)
-                  .show()
-            } else {
-              Toast.makeText(
-                      context,
-                      context.getString(R.string.welcome_toast_verification_sent_failed),
-                      Toast.LENGTH_SHORT)
-                  .show()
-              Log.e("WelcomeScreen", "Failed to send verification email", it.exception)
-            }
-          }
-        }
-      }
-      SignInState.SUCCESS_CREATE_ACCOUNT -> {
-        Toast.makeText(
-                context,
-                context.getString(R.string.welcome_toast_account_created),
-                Toast.LENGTH_SHORT)
-            .show()
-
-        signInResult.user?.sendEmailVerification()?.addOnCompleteListener {
-          if (it.isSuccessful) {
-            Toast.makeText(
-                    context,
-                    context.getString(R.string.welcome_toast_verification_sent),
-                    Toast.LENGTH_SHORT)
-                .show()
-          } else {
-            Toast.makeText(
-                    context,
-                    context.getString(R.string.welcome_toast_verification_sent_failed),
-                    Toast.LENGTH_SHORT)
-                .show()
-            Log.e("WelcomeScreen", "Failed to send verification email", it.exception)
-          }
-        }
-      }
+    // Check internet connectivity
+    val isConnected = checkInternetConnection(context)
+    if (!isConnected) {
+        Toast.makeText(context, "You appear to be offline.", Toast.LENGTH_SHORT).show()
+        return
     }
-  }
+
+    signInOrCreateAccount(email, password, Firebase.auth) { signInResult ->
+        // NOTE: No need to navigate to other screens, that is already handled by the listener in
+        // MainActivity
+        when (signInResult.state) {
+            SignInState.INVALID_CREDENTIALS -> {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.welcome_toast_invalid_creds),
+                    Toast.LENGTH_SHORT
+                )
+                    .show()
+            }
+
+            SignInState.INVALID_EMAIL_FORMAT -> {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.welcome_toast_enter_valid_email),
+                    Toast.LENGTH_SHORT
+                )
+                    .show()
+            }
+
+            SignInState.SUCCESS_SIGN_IN -> {
+                Toast.makeText(
+                    context, context.getString(R.string.welcome_toast_sign_in), Toast.LENGTH_SHORT
+                )
+                    .show()
+
+                if (signInResult.user?.isEmailVerified == false) {
+                    signInResult.user.sendEmailVerification().addOnCompleteListener {
+                        if (it.isSuccessful) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.welcome_toast_verification_sent),
+                                Toast.LENGTH_SHORT
+                            )
+                                .show()
+                        } else {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.welcome_toast_verification_sent_failed),
+                                Toast.LENGTH_SHORT
+                            )
+                                .show()
+                            Log.e(
+                                "WelcomeScreen",
+                                "Failed to send verification email",
+                                it.exception
+                            )
+                        }
+                    }
+                }
+            }
+
+            SignInState.SUCCESS_CREATE_ACCOUNT -> {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.welcome_toast_account_created),
+                    Toast.LENGTH_SHORT
+                )
+                    .show()
+
+                signInResult.user?.sendEmailVerification()?.addOnCompleteListener {
+                    if (it.isSuccessful) {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.welcome_toast_verification_sent),
+                            Toast.LENGTH_SHORT
+                        )
+                            .show()
+                    } else {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.welcome_toast_verification_sent_failed),
+                            Toast.LENGTH_SHORT
+                        )
+                            .show()
+                        Log.e("WelcomeScreen", "Failed to send verification email", it.exception)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
+++ b/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
@@ -1,7 +1,6 @@
 package com.android.unio.ui.authentication
 
 import android.content.Context
-import android.net.ConnectivityManager
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
@@ -42,7 +41,6 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign.Companion.Center
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat.getSystemService
 import com.android.unio.R
 import com.android.unio.model.strings.test_tags.WelcomeTestTags
 import com.android.unio.model.user.SignInState
@@ -50,6 +48,7 @@ import com.android.unio.model.user.UserViewModel
 import com.android.unio.model.user.isValidEmail
 import com.android.unio.model.user.isValidPassword
 import com.android.unio.model.user.signInOrCreateAccount
+import com.android.unio.model.utils.Utils.checkInternetConnection
 import com.android.unio.ui.theme.AppTypography
 import com.google.firebase.Firebase
 import com.google.firebase.auth.EmailAuthProvider
@@ -169,8 +168,8 @@ fun WelcomeScreen(userViewModel: UserViewModel) {
 fun handleAuthentication(email: String, password: String, context: Context) {
 
   // Check internet connectivity
-  val connectivityManager = getSystemService(context, ConnectivityManager::class.java)
-  if (connectivityManager?.activeNetwork == null) {
+  val isConnected = checkInternetConnection(context)
+  if (!isConnected) {
     Toast.makeText(context, "You appear to be offline.", Toast.LENGTH_SHORT).show()
     return
   }

--- a/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
+++ b/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
@@ -56,226 +56,190 @@ import com.google.firebase.auth.auth
 
 @Composable
 fun WelcomeScreen(userViewModel: UserViewModel) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    var email by remember { mutableStateOf("") }
-    var password by remember { mutableStateOf("") }
+  var email by remember { mutableStateOf("") }
+  var password by remember { mutableStateOf("") }
 
-    var showPassword by remember { mutableStateOf(false) }
+  var showPassword by remember { mutableStateOf(false) }
 
-    val validEmail = isValidEmail(email)
-    val validPassword = isValidPassword(password)
-    val enabled = validEmail && validPassword
+  val validEmail = isValidEmail(email)
+  val validPassword = isValidPassword(password)
+  val enabled = validEmail && validPassword
 
-    val passwordError = !validPassword && password.isNotEmpty()
+  val passwordError = !validPassword && password.isNotEmpty()
 
-    Scaffold(
-        modifier = Modifier
-            .testTag(WelcomeTestTags.SCREEN)
-            .fillMaxSize(),
-        content = { padding ->
-            Column(
-                modifier = Modifier
-                    .padding(padding)
-                    .fillMaxSize(),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Box(modifier = Modifier
-                    .clip(CircleShape)
-                    .size(150.dp)
-                    .background(Color.Gray))
-                Spacer(modifier = Modifier.size(20.dp))
+  Scaffold(
+      modifier = Modifier.testTag(WelcomeTestTags.SCREEN).fillMaxSize(),
+      content = { padding ->
+        Column(
+            modifier = Modifier.padding(padding).fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              Box(modifier = Modifier.clip(CircleShape).size(150.dp).background(Color.Gray))
+              Spacer(modifier = Modifier.size(20.dp))
 
-                Text(
-                    context.getString(R.string.welcome_message),
-                    style = AppTypography.titleLarge,
-                    modifier = Modifier.fillMaxWidth(0.8f),
-                    textAlign = Center
-                )
+              Text(
+                  context.getString(R.string.welcome_message),
+                  style = AppTypography.titleLarge,
+                  modifier = Modifier.fillMaxWidth(0.8f),
+                  textAlign = Center)
 
-                Spacer(modifier = Modifier.size(50.dp))
-                Text(
-                    context.getString(R.string.welcome_login_signup),
-                    style = AppTypography.titleMedium
-                )
+              Spacer(modifier = Modifier.size(50.dp))
+              Text(
+                  context.getString(R.string.welcome_login_signup),
+                  style = AppTypography.titleMedium)
 
-                OutlinedTextField(
-                    modifier = Modifier.testTag(WelcomeTestTags.EMAIL),
-                    value = email,
-                    onValueChange = { email = it },
-                    keyboardOptions =
-                    KeyboardOptions(
-                        keyboardType = KeyboardType.Email,
-                        imeAction = ImeAction.Done,
-                        capitalization = KeyboardCapitalization.None
-                    ),
-                    singleLine = true,
-                    label = { Text(context.getString(R.string.welcome_email_enter)) },
-                    placeholder = { Text(context.getString(R.string.welcome_email_display)) },
-                )
+              OutlinedTextField(
+                  modifier = Modifier.testTag(WelcomeTestTags.EMAIL),
+                  value = email,
+                  onValueChange = { email = it },
+                  keyboardOptions =
+                      KeyboardOptions(
+                          keyboardType = KeyboardType.Email,
+                          imeAction = ImeAction.Done,
+                          capitalization = KeyboardCapitalization.None),
+                  singleLine = true,
+                  label = { Text(context.getString(R.string.welcome_email_enter)) },
+                  placeholder = { Text(context.getString(R.string.welcome_email_display)) },
+              )
 
-                OutlinedTextField(
-                    modifier = Modifier.testTag(WelcomeTestTags.PASSWORD),
-                    value = password,
-                    onValueChange = { password = it },
-                    keyboardOptions =
-                    KeyboardOptions(
-                        keyboardType = KeyboardType.Password,
-                        imeAction = ImeAction.Done,
-                        capitalization = KeyboardCapitalization.None
-                    ),
-                    singleLine = true,
-                    label = { Text(context.getString(R.string.welcome_password_enter)) },
-                    isError = passwordError,
-                    supportingText = {
-                        if (passwordError) {
-                            Text(context.getString(R.string.welcome_password_error_correction))
-                        }
-                    },
-                    trailingIcon = {
-                        IconButton(
-                            onClick = { showPassword = !showPassword },
-                        ) {
-                            Icon(
-                                if (showPassword) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
-                                contentDescription =
-                                if (showPassword)
-                                    context.getString(
-                                        R.string.welcome_content_description_hide_password
-                                    )
-                                else
-                                    context.getString(
-                                        R.string.welcome_content_description_show_password
-                                    ),
-                            )
-                        }
-                    },
-                    visualTransformation =
-                    if (showPassword) VisualTransformation.None
-                    else PasswordVisualTransformation(),
-                )
+              OutlinedTextField(
+                  modifier = Modifier.testTag(WelcomeTestTags.PASSWORD),
+                  value = password,
+                  onValueChange = { password = it },
+                  keyboardOptions =
+                      KeyboardOptions(
+                          keyboardType = KeyboardType.Password,
+                          imeAction = ImeAction.Done,
+                          capitalization = KeyboardCapitalization.None),
+                  singleLine = true,
+                  label = { Text(context.getString(R.string.welcome_password_enter)) },
+                  isError = passwordError,
+                  supportingText = {
+                    if (passwordError) {
+                      Text(context.getString(R.string.welcome_password_error_correction))
+                    }
+                  },
+                  trailingIcon = {
+                    IconButton(
+                        onClick = { showPassword = !showPassword },
+                    ) {
+                      Icon(
+                          if (showPassword) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                          contentDescription =
+                              if (showPassword)
+                                  context.getString(
+                                      R.string.welcome_content_description_hide_password)
+                              else
+                                  context.getString(
+                                      R.string.welcome_content_description_show_password),
+                      )
+                    }
+                  },
+                  visualTransformation =
+                      if (showPassword) VisualTransformation.None
+                      else PasswordVisualTransformation(),
+              )
 
-                Spacer(modifier = Modifier.size(70.dp))
+              Spacer(modifier = Modifier.size(70.dp))
 
-                Button(
-                    modifier = Modifier.testTag(WelcomeTestTags.BUTTON),
-                    onClick = {
-                        if (!enabled) {
-                            Toast.makeText(
-                                context,
-                                context.getString(R.string.welcome_malformed_email_password),
-                                Toast.LENGTH_SHORT
-                            )
-                                .show()
-                        } else {
-                            userViewModel.setCredential(
-                                EmailAuthProvider.getCredential(
-                                    email,
-                                    password
-                                )
-                            )
-                            handleAuthentication(email, password, context)
-                        }
-                    },
-                    enabled = enabled
-                ) {
+              Button(
+                  modifier = Modifier.testTag(WelcomeTestTags.BUTTON),
+                  onClick = {
+                    if (!enabled) {
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.welcome_malformed_email_password),
+                              Toast.LENGTH_SHORT)
+                          .show()
+                    } else {
+                      userViewModel.setCredential(EmailAuthProvider.getCredential(email, password))
+                      handleAuthentication(email, password, context)
+                    }
+                  },
+                  enabled = enabled) {
                     Text(context.getString(R.string.welcome_button_continue))
-                }
+                  }
             }
-        })
+      })
 }
 
 fun handleAuthentication(email: String, password: String, context: Context) {
 
-    // Check internet connectivity
-    val isConnected = checkInternetConnection(context)
-    if (!isConnected) {
-        Toast.makeText(context, "You appear to be offline.", Toast.LENGTH_SHORT).show()
-        return
-    }
+  // Check internet connectivity
+  val isConnected = checkInternetConnection(context)
+  if (!isConnected) {
+    Toast.makeText(context, "You appear to be offline.", Toast.LENGTH_SHORT).show()
+    return
+  }
 
-    signInOrCreateAccount(email, password, Firebase.auth) { signInResult ->
-        // NOTE: No need to navigate to other screens, that is already handled by the listener in
-        // MainActivity
-        when (signInResult.state) {
-            SignInState.INVALID_CREDENTIALS -> {
-                Toast.makeText(
-                    context,
-                    context.getString(R.string.welcome_toast_invalid_creds),
-                    Toast.LENGTH_SHORT
-                )
-                    .show()
+  signInOrCreateAccount(email, password, Firebase.auth) { signInResult ->
+    // NOTE: No need to navigate to other screens, that is already handled by the listener in
+    // MainActivity
+    when (signInResult.state) {
+      SignInState.INVALID_CREDENTIALS -> {
+        Toast.makeText(
+                context,
+                context.getString(R.string.welcome_toast_invalid_creds),
+                Toast.LENGTH_SHORT)
+            .show()
+      }
+      SignInState.INVALID_EMAIL_FORMAT -> {
+        Toast.makeText(
+                context,
+                context.getString(R.string.welcome_toast_enter_valid_email),
+                Toast.LENGTH_SHORT)
+            .show()
+      }
+      SignInState.SUCCESS_SIGN_IN -> {
+        Toast.makeText(
+                context, context.getString(R.string.welcome_toast_sign_in), Toast.LENGTH_SHORT)
+            .show()
+
+        if (signInResult.user?.isEmailVerified == false) {
+          signInResult.user.sendEmailVerification().addOnCompleteListener {
+            if (it.isSuccessful) {
+              Toast.makeText(
+                      context,
+                      context.getString(R.string.welcome_toast_verification_sent),
+                      Toast.LENGTH_SHORT)
+                  .show()
+            } else {
+              Toast.makeText(
+                      context,
+                      context.getString(R.string.welcome_toast_verification_sent_failed),
+                      Toast.LENGTH_SHORT)
+                  .show()
+              Log.e("WelcomeScreen", "Failed to send verification email", it.exception)
             }
-
-            SignInState.INVALID_EMAIL_FORMAT -> {
-                Toast.makeText(
-                    context,
-                    context.getString(R.string.welcome_toast_enter_valid_email),
-                    Toast.LENGTH_SHORT
-                )
-                    .show()
-            }
-
-            SignInState.SUCCESS_SIGN_IN -> {
-                Toast.makeText(
-                    context, context.getString(R.string.welcome_toast_sign_in), Toast.LENGTH_SHORT
-                )
-                    .show()
-
-                if (signInResult.user?.isEmailVerified == false) {
-                    signInResult.user.sendEmailVerification().addOnCompleteListener {
-                        if (it.isSuccessful) {
-                            Toast.makeText(
-                                context,
-                                context.getString(R.string.welcome_toast_verification_sent),
-                                Toast.LENGTH_SHORT
-                            )
-                                .show()
-                        } else {
-                            Toast.makeText(
-                                context,
-                                context.getString(R.string.welcome_toast_verification_sent_failed),
-                                Toast.LENGTH_SHORT
-                            )
-                                .show()
-                            Log.e(
-                                "WelcomeScreen",
-                                "Failed to send verification email",
-                                it.exception
-                            )
-                        }
-                    }
-                }
-            }
-
-            SignInState.SUCCESS_CREATE_ACCOUNT -> {
-                Toast.makeText(
-                    context,
-                    context.getString(R.string.welcome_toast_account_created),
-                    Toast.LENGTH_SHORT
-                )
-                    .show()
-
-                signInResult.user?.sendEmailVerification()?.addOnCompleteListener {
-                    if (it.isSuccessful) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.welcome_toast_verification_sent),
-                            Toast.LENGTH_SHORT
-                        )
-                            .show()
-                    } else {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.welcome_toast_verification_sent_failed),
-                            Toast.LENGTH_SHORT
-                        )
-                            .show()
-                        Log.e("WelcomeScreen", "Failed to send verification email", it.exception)
-                    }
-                }
-            }
+          }
         }
+      }
+      SignInState.SUCCESS_CREATE_ACCOUNT -> {
+        Toast.makeText(
+                context,
+                context.getString(R.string.welcome_toast_account_created),
+                Toast.LENGTH_SHORT)
+            .show()
+
+        signInResult.user?.sendEmailVerification()?.addOnCompleteListener {
+          if (it.isSuccessful) {
+            Toast.makeText(
+                    context,
+                    context.getString(R.string.welcome_toast_verification_sent),
+                    Toast.LENGTH_SHORT)
+                .show()
+          } else {
+            Toast.makeText(
+                    context,
+                    context.getString(R.string.welcome_toast_verification_sent_failed),
+                    Toast.LENGTH_SHORT)
+                .show()
+            Log.e("WelcomeScreen", "Failed to send verification email", it.exception)
+          }
+        }
+      }
     }
+  }
 }

--- a/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
+++ b/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
@@ -170,7 +170,8 @@ fun handleAuthentication(email: String, password: String, context: Context) {
   // Check internet connectivity
   val isConnected = checkInternetConnection(context)
   if (!isConnected) {
-    Toast.makeText(context, context.getString(R.string.no_internet_connection), Toast.LENGTH_SHORT).show()
+    Toast.makeText(context, context.getString(R.string.no_internet_connection), Toast.LENGTH_SHORT)
+        .show()
     return
   }
 

--- a/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
+++ b/app/src/main/java/com/android/unio/ui/authentication/Welcome.kt
@@ -170,7 +170,7 @@ fun handleAuthentication(email: String, password: String, context: Context) {
   // Check internet connectivity
   val isConnected = checkInternetConnection(context)
   if (!isConnected) {
-    Toast.makeText(context, "You appear to be offline.", Toast.LENGTH_SHORT).show()
+    Toast.makeText(context, context.getString(R.string.no_internet_connection), Toast.LENGTH_SHORT).show()
     return
   }
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -285,6 +285,9 @@
     * Other
     */
 
+    <!-- General Strings -->
+    <string name="no_internet_connection">Il semble que vous êtes hors-ligne</string>
+
     <!-- EventListOverview Strings -->
     <string name="event_upcomingEvents">Évènements à venir</string>
     <string name="event_tab_all">Tous</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -286,7 +286,7 @@
     */
 
     <!-- General Strings -->
-    <string name="no_internet_connection">Il semble que vous êtes hors-ligne</string>
+    <string name="no_internet_connection">Vous semblez être hors-ligne</string>
 
     <!-- EventListOverview Strings -->
     <string name="event_upcomingEvents">Évènements à venir</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,6 +317,9 @@
     * Other
     */
 
+    <!-- General Strings -->
+    <string name="no_internet_connection">You appear to be offline</string>
+
     <!-- EventListOverview Strings -->
     <string name="event_upcomingEvents">Upcoming Events</string>
     <string name="event_tab_all">All</string>


### PR DESCRIPTION
There are multiple feature that do not work in offline mode. The "following" feature is one of them.

The user has to leave the screen and come back for the button to be clickable again, and the follow count isn't increased.
When you follow an association, two repositories are essentially called in ConcurrentAssociationUserRepositoryFirestore, which runs the calls in a runBatch.
I suspect this batch operation is the issue, and has to be handled differently to work with offline mode, or another operation should be done after to fix the bug.
