### PR TITLE
Feature/edit and delete event

### DIFF
--- a/app/src/androidTest/java/com/android/unio/components/BottomNavigationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/BottomNavigationTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import com.android.unio.TearDown
+import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.event.EventRepository
 import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
@@ -31,6 +32,7 @@ class BottomNavigationTest : TearDown() {
   private lateinit var eventViewModel: EventViewModel
 
   @MockK private lateinit var imageRepository: ImageRepositoryFirebaseStorage
+  @MockK private lateinit var associationRepositoryFirestore: AssociationRepositoryFirestore
 
   private lateinit var userRepository: UserRepository
   private lateinit var userViewModel: UserViewModel
@@ -44,7 +46,8 @@ class BottomNavigationTest : TearDown() {
   fun setUp() {
     MockKAnnotations.init(this)
     eventRepository = mock { EventRepository::class.java }
-    eventViewModel = EventViewModel(eventRepository, imageRepository)
+    eventViewModel =
+        EventViewModel(eventRepository, imageRepository, associationRepositoryFirestore)
 
     userRepository = mock { UserRepositoryFirestore::class.java }
     userViewModel = UserViewModel(userRepository, false)

--- a/app/src/androidTest/java/com/android/unio/components/ScreenDisplayingTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/ScreenDisplayingTest.kt
@@ -10,6 +10,7 @@ import com.android.unio.TearDown
 import com.android.unio.mocks.association.MockAssociation
 import com.android.unio.mocks.event.MockEvent
 import com.android.unio.mocks.user.MockUser
+import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.association.AssociationViewModel
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepositoryFirestore
@@ -99,6 +100,7 @@ class ScreenDisplayingTest : TearDown() {
         longitude = 6.559331096
       }
 
+  @MockK private lateinit var associationRepositoryFirestore: AssociationRepositoryFirestore
   @MockK private lateinit var imageRepositoryFirestore: ImageRepositoryFirebaseStorage
 
   @MockK private lateinit var firebaseAuth: FirebaseAuth
@@ -130,7 +132,7 @@ class ScreenDisplayingTest : TearDown() {
     associationViewModel =
         spyk(
             AssociationViewModel(
-                mock(),
+                associationRepositoryFirestore,
                 mockk<EventRepositoryFirestore>(),
                 imageRepositoryFirestore,
                 mockk<ConcurrentAssociationUserRepositoryFirestore>()))
@@ -140,7 +142,8 @@ class ScreenDisplayingTest : TearDown() {
           val onSuccess = args[0] as (List<Event>) -> Unit
           onSuccess(events)
         }
-    eventViewModel = EventViewModel(eventRepository, imageRepositoryFirestore)
+    eventViewModel =
+        EventViewModel(eventRepository, imageRepositoryFirestore, associationRepositoryFirestore)
     eventViewModel.loadEvents()
     eventViewModel.selectEvent(events.first().uid)
 

--- a/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
@@ -132,7 +132,7 @@ class AssociationProfileTest : TearDown() {
           val onSuccess = args[0] as (List<Event>) -> Unit
           onSuccess(events)
         }
-    eventViewModel = EventViewModel(eventRepository, imageRepository)
+    eventViewModel = EventViewModel(eventRepository, imageRepository, associationRepository)
 
     every { associationRepository.init(any()) } answers { firstArg<() -> Unit>().invoke() }
     every { associationRepository.getAssociations(any(), any()) } answers

--- a/app/src/androidTest/java/com/android/unio/components/event/EventCreationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/event/EventCreationTest.kt
@@ -81,7 +81,8 @@ class EventCreationTest : TearDown() {
           val onSuccess = args[0] as (List<Event>) -> Unit
           onSuccess(events)
         }
-    eventViewModel = EventViewModel(eventRepository, imageRepositoryFirestore)
+    eventViewModel =
+        EventViewModel(eventRepository, imageRepositoryFirestore, associationRepositoryFirestore)
 
     searchViewModel = spyk(SearchViewModel(searchRepository))
     associationViewModel =

--- a/app/src/androidTest/java/com/android/unio/components/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/home/HomeTest.kt
@@ -15,6 +15,7 @@ import com.android.unio.assertDisplayComponentInScroll
 import com.android.unio.mocks.association.MockAssociation
 import com.android.unio.mocks.event.MockEvent
 import com.android.unio.mocks.user.MockUser
+import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepositoryFirestore
 import com.android.unio.model.event.EventViewModel
@@ -69,6 +70,7 @@ class HomeTest : TearDown() {
   @MockK private lateinit var userRepository: UserRepositoryFirestore
   @MockK private lateinit var imageRepository: ImageRepositoryFirebaseStorage
   @MockK private lateinit var navigationAction: NavigationAction
+  @MockK private lateinit var associationRepositoryFirestore: AssociationRepositoryFirestore
 
   private lateinit var eventViewModel: EventViewModel
   private lateinit var searchViewModel: SearchViewModel
@@ -120,7 +122,8 @@ class HomeTest : TearDown() {
           val onSuccess = args[0] as (List<Event>) -> Unit
           onSuccess(eventList)
         }
-    eventViewModel = EventViewModel(eventRepository, imageRepository)
+    eventViewModel =
+        EventViewModel(eventRepository, imageRepository, associationRepositoryFirestore)
     eventListFollowed = asso.let { eventList.filter { event -> event.organisers.contains(it.uid) } }
   }
 
@@ -140,7 +143,8 @@ class HomeTest : TearDown() {
     composeTestRule.setContent {
       val context = LocalContext.current
       text = context.getString(R.string.event_no_events_available)
-      val eventViewModel = EventViewModel(eventRepository, imageRepository)
+      val eventViewModel =
+          EventViewModel(eventRepository, imageRepository, associationRepositoryFirestore)
       HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel)
     }
     composeTestRule.onNodeWithTag(HomeTestTags.EMPTY_EVENT_PROMPT).assertExists()
@@ -188,7 +192,8 @@ class HomeTest : TearDown() {
   @Test
   fun testMapButton() {
     composeTestRule.setContent {
-      val eventViewModel = EventViewModel(eventRepository, imageRepository)
+      val eventViewModel =
+          EventViewModel(eventRepository, imageRepository, associationRepositoryFirestore)
       HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel)
     }
     composeTestRule.onNodeWithTag(HomeTestTags.MAP_BUTTON).assertExists()
@@ -206,7 +211,8 @@ class HomeTest : TearDown() {
   @Test
   fun testClickFollowingAndAdd() = runBlockingTest {
     composeTestRule.setContent {
-      val eventViewModel = EventViewModel(eventRepository, imageRepository)
+      val eventViewModel =
+          EventViewModel(eventRepository, imageRepository, associationRepositoryFirestore)
       HomeScreen(navigationAction, eventViewModel, userViewModel, searchViewModel)
     }
 

--- a/app/src/androidTest/java/com/android/unio/components/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/map/MapScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.android.unio.TearDown
 import com.android.unio.mocks.user.MockUser
+import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.event.EventRepositoryFirestore
 import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
@@ -54,6 +55,7 @@ class MapScreenTest : TearDown() {
   @MockK private lateinit var imageRepository: ImageRepositoryFirebaseStorage
   @MockK private lateinit var userRepository: UserRepositoryFirestore
   @MockK private lateinit var navHostController: NavHostController
+  @MockK private lateinit var associationRepositoryFirestore: AssociationRepositoryFirestore
 
   private lateinit var locationTask: Task<Location>
   private lateinit var context: Context
@@ -76,7 +78,8 @@ class MapScreenTest : TearDown() {
     navigationAction = NavigationAction(navHostController)
 
     every { eventRepository.init(any()) } answers {}
-    eventViewModel = EventViewModel(eventRepository, imageRepository)
+    eventViewModel =
+        EventViewModel(eventRepository, imageRepository, associationRepositoryFirestore)
 
     every { userRepository.init(any()) } returns Unit
     every { userRepository.getUserWithId("123", any(), any()) } answers

--- a/app/src/androidTest/java/com/android/unio/components/saved/SavedTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/saved/SavedTest.kt
@@ -7,6 +7,7 @@ import com.android.unio.assertDisplayComponentInScroll
 import com.android.unio.mocks.association.MockAssociation
 import com.android.unio.mocks.event.MockEvent
 import com.android.unio.mocks.user.MockUser
+import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepositoryFirestore
 import com.android.unio.model.event.EventViewModel
@@ -38,11 +39,9 @@ class SavedTest : TearDown() {
 
   // Mock event repository to provide test data.
   @MockK private lateinit var eventRepository: EventRepositoryFirestore
-
   @MockK private lateinit var userRepository: UserRepositoryFirestore
-
   @MockK private lateinit var navigationAction: NavigationAction
-
+  @MockK private lateinit var associationRepositoryFirestore: AssociationRepositoryFirestore
   @MockK private lateinit var imageRepository: ImageRepositoryFirebaseStorage
 
   private lateinit var eventViewModel: EventViewModel
@@ -87,7 +86,8 @@ class SavedTest : TearDown() {
           onSuccess()
         }
 
-    eventViewModel = EventViewModel(eventRepository, imageRepository)
+    eventViewModel =
+        EventViewModel(eventRepository, imageRepository, associationRepositoryFirestore)
   }
 
   @Test

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -34,6 +34,7 @@ import com.android.unio.ui.authentication.AccountDetailsScreen
 import com.android.unio.ui.authentication.EmailVerificationScreen
 import com.android.unio.ui.authentication.WelcomeScreen
 import com.android.unio.ui.event.EventCreationScreen
+import com.android.unio.ui.event.EventEditScreen
 import com.android.unio.ui.event.EventScreen
 import com.android.unio.ui.explore.ExploreScreen
 import com.android.unio.ui.home.HomeScreen
@@ -147,6 +148,9 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
           EventCreationScreen(
               navigationActions, searchViewModel, associationViewModel, eventViewModel)
         }
+      }
+      composable(Screen.EDIT_EVENT) {
+        EventEditScreen(navigationActions, searchViewModel, associationViewModel, eventViewModel)
       }
     }
     navigation(startDestination = Screen.SAVED, route = Route.SAVED) {

--- a/app/src/main/java/com/android/unio/model/event/EventRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/event/EventRepositoryFirestore.kt
@@ -84,7 +84,7 @@ class EventRepositoryFirestore @Inject constructor(private val db: FirebaseFires
     return db.collection(EVENT_PATH).document().id
   }
 
-  // TODO rename this as it also serves as the updateEvent function
+  /** Updates the event in the repository or adds it if it does not exist. */
   override fun addEvent(event: Event, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     if (event.uid.isBlank()) {
       onFailure(IllegalArgumentException("No event id was provided"))

--- a/app/src/main/java/com/android/unio/model/event/EventRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/unio/model/event/EventRepositoryFirestore.kt
@@ -84,6 +84,7 @@ class EventRepositoryFirestore @Inject constructor(private val db: FirebaseFires
     return db.collection(EVENT_PATH).document().id
   }
 
+  // TODO rename this as it also serves as the updateEvent function
   override fun addEvent(event: Event, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     if (event.uid.isBlank()) {
       onFailure(IllegalArgumentException("No event id was provided"))

--- a/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
@@ -99,8 +99,13 @@ constructor(private val repository: EventRepository, private val imageRepository
   }
 
   /**
-   * Update an existing event in the repository. It uploads the event image first, then updates the
-   * event.
+   * Update an existing event in the repository with a new image. It uploads the event image first,
+   * then updates the event.
+   *
+   * @param inputStream The input stream of the image to upload.
+   * @param event The event to update.
+   * @param onSuccess A callback that is called when the event is successfully updated.
+   * @param onFailure A callback that is called when an error occurs while updating the event.
    */
   fun updateEvent(
       inputStream: InputStream,
@@ -123,8 +128,11 @@ constructor(private val repository: EventRepository, private val imageRepository
   }
 
   /**
-   * Update an existing event in the repository. It uploads the event image first, then updates the
-   * event.
+   * Update an existing event in the repository without updating its image.
+   *
+   * @param event The event to update.
+   * @param onSuccess A callback that is called when the event is successfully updated.
+   * @param onFailure A callback that is called when an error occurs while updating the event.
    */
   fun updateEventWithoutImage(event: Event, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     repository.addEvent(event, onSuccess, onFailure)
@@ -138,6 +146,8 @@ constructor(private val repository: EventRepository, private val imageRepository
    * Deletes an event from the repository.
    *
    * @param eventId The ID of the event to delete.
+   * @param onSuccess A callback that is called when the event is successfully deleted.
+   * @param onFailure A callback that is called when an error occurs while deleting the event.
    */
   fun deleteEvent(eventId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     repository.deleteEventById(

--- a/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/event/EventViewModel.kt
@@ -117,25 +117,22 @@ constructor(private val repository: EventRepository, private val imageRepository
         },
         { e -> Log.e("ImageRepository", "Failed to store image: $e") })
     event.organisers.requestAll(onSuccess)
-      // TODO check if this should only be done if the above is successful
-      _events.value = _events.value.filter { it.uid != event.uid } // Remove the outdated event
-      _events.value += event
+    // TODO check if this should only be done if the above is successful
+    _events.value = _events.value.filter { it.uid != event.uid } // Remove the outdated event
+    _events.value += event
   }
 
-    /**
-     * Deletes an event from the repository.
-     *
-     * @param eventId The ID of the event to delete.
-     */
-    fun deleteEvent(eventId: String) {
-        repository.deleteEventById(
-            eventId,
-            onSuccess = {
-                _events.value = _events.value.filter { it.uid != eventId }
-            },
-            onFailure = { exception ->
-                Log.e("EventViewModel", "An error occurred while deleting event: $exception")
-            }
-        )
-    }
+  /**
+   * Deletes an event from the repository.
+   *
+   * @param eventId The ID of the event to delete.
+   */
+  fun deleteEvent(eventId: String) {
+    repository.deleteEventById(
+        eventId,
+        onSuccess = { _events.value = _events.value.filter { it.uid != eventId } },
+        onFailure = { exception ->
+          Log.e("EventViewModel", "An error occurred while deleting event: $exception")
+        })
+  }
 }

--- a/app/src/main/java/com/android/unio/model/strings/test_tags/EventTestTags.kt
+++ b/app/src/main/java/com/android/unio/model/strings/test_tags/EventTestTags.kt
@@ -39,6 +39,24 @@ object EventCreationOverlayTestTags {
   const val ASSOCIATION_LIST = "eventCreationOverlayAssociationList"
 }
 
+object EventEditTestTags {
+    const val SCREEN = "eventEditScreen"
+    const val TITLE = "eventEditTitle"
+    const val EVENT_TITLE = "eventEditEventTitle"
+    const val SHORT_DESCRIPTION = "eventEditShortDescription"
+    const val COAUTHORS = "eventEditCoauthors"
+    const val TAGGED_ASSOCIATIONS = "eventEditTaggedAssociations"
+    const val DESCRIPTION = "eventEditDescription"
+    const val LOCATION = "eventEditLocation"
+    const val SAVE_BUTTON = "eventEditSaveButton"
+    const val DELETE_BUTTON = "eventEditDeleteButton"
+    const val EVENT_IMAGE = "eventEditEventImage"
+    const val START_TIME = "eventEditStartTime"
+    const val END_TIME = "eventEditEndTime"
+    const val ERROR_TEXT1 = "eventEditStartAfterEnd"
+    const val ERROR_TEXT2 = "eventEditStartEqualsEnd"
+}
+
 object EventDetailsTestTags {
   const val SCREEN = "eventScreen"
   const val SNACKBAR_HOST = "snackbarHost"

--- a/app/src/main/java/com/android/unio/model/strings/test_tags/EventTestTags.kt
+++ b/app/src/main/java/com/android/unio/model/strings/test_tags/EventTestTags.kt
@@ -40,21 +40,21 @@ object EventCreationOverlayTestTags {
 }
 
 object EventEditTestTags {
-    const val SCREEN = "eventEditScreen"
-    const val TITLE = "eventEditTitle"
-    const val EVENT_TITLE = "eventEditEventTitle"
-    const val SHORT_DESCRIPTION = "eventEditShortDescription"
-    const val COAUTHORS = "eventEditCoauthors"
-    const val TAGGED_ASSOCIATIONS = "eventEditTaggedAssociations"
-    const val DESCRIPTION = "eventEditDescription"
-    const val LOCATION = "eventEditLocation"
-    const val SAVE_BUTTON = "eventEditSaveButton"
-    const val DELETE_BUTTON = "eventEditDeleteButton"
-    const val EVENT_IMAGE = "eventEditEventImage"
-    const val START_TIME = "eventEditStartTime"
-    const val END_TIME = "eventEditEndTime"
-    const val ERROR_TEXT1 = "eventEditStartAfterEnd"
-    const val ERROR_TEXT2 = "eventEditStartEqualsEnd"
+  const val SCREEN = "eventEditScreen"
+  const val TITLE = "eventEditTitle"
+  const val EVENT_TITLE = "eventEditEventTitle"
+  const val SHORT_DESCRIPTION = "eventEditShortDescription"
+  const val COAUTHORS = "eventEditCoauthors"
+  const val TAGGED_ASSOCIATIONS = "eventEditTaggedAssociations"
+  const val DESCRIPTION = "eventEditDescription"
+  const val LOCATION = "eventEditLocation"
+  const val SAVE_BUTTON = "eventEditSaveButton"
+  const val DELETE_BUTTON = "eventEditDeleteButton"
+  const val EVENT_IMAGE = "eventEditEventImage"
+  const val START_TIME = "eventEditStartTime"
+  const val END_TIME = "eventEditEndTime"
+  const val ERROR_TEXT1 = "eventEditStartAfterEnd"
+  const val ERROR_TEXT2 = "eventEditStartEqualsEnd"
 }
 
 object EventDetailsTestTags {

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -502,7 +502,9 @@ private fun AssociationEventCard(
         navigationAction = navigationAction,
         event = event,
         userViewModel = userViewModel,
-        eventViewModel = eventViewModel)
+        eventViewModel = eventViewModel,
+        true
+    )
   }
 }
 

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -503,8 +503,7 @@ private fun AssociationEventCard(
         event = event,
         userViewModel = userViewModel,
         eventViewModel = eventViewModel,
-        true
-    )
+        true)
   }
 }
 

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -137,7 +138,6 @@ fun AssociationProfileScaffold(
     associationViewModel: AssociationViewModel,
     onEdit: () -> Unit
 ) {
-
   val associationState by associationViewModel.selectedAssociation.collectAsState()
   val association = associationState!!
 
@@ -295,6 +295,11 @@ private fun AssociationProfileContent(
     navigationAction.navigateTo(Screen.SOMEONE_ELSE_PROFILE)
   }
 
+  var events by remember { mutableStateOf<List<Event>>(emptyList()) }
+  LaunchedEffect(Unit) {
+    associationViewModel.getEventsForAssociation(association!!, { events = it })
+  }
+
   // Add spacedBy to the horizontalArrangement
   Column(
       modifier =
@@ -305,7 +310,7 @@ private fun AssociationProfileContent(
       verticalArrangement = Arrangement.spacedBy(16.dp)) {
         AssociationHeader(association!!, isFollowed, enableButton, onFollow)
         AssociationDescription(association!!)
-        AssociationEvents(navigationAction, association!!, userViewModel, eventViewModel)
+        AssociationEvents(navigationAction, association!!, userViewModel, eventViewModel, events)
         AssociationMembers(members, onMemberClick)
         AssociationRecruitment(association!!)
       }
@@ -433,13 +438,12 @@ private fun AssociationEvents(
     navigationAction: NavigationAction,
     association: Association,
     userViewModel: UserViewModel,
-    eventViewModel: EventViewModel
+    eventViewModel: EventViewModel,
+    events: List<Event>
 ) {
   val context = LocalContext.current
 
   var isSeeMoreClicked by remember { mutableStateOf(false) }
-
-  val events by association.events.list.collectAsState()
 
   var isAdmin by remember { mutableStateOf(true) }
 

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -445,6 +445,7 @@ private fun AssociationEvents(
 
   var isSeeMoreClicked by remember { mutableStateOf(false) }
 
+  // To be changed when we have a functional admin system
   var isAdmin by remember { mutableStateOf(true) }
 
   if (events.isNotEmpty()) {

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -295,10 +294,12 @@ private fun AssociationProfileContent(
     navigationAction.navigateTo(Screen.SOMEONE_ELSE_PROFILE)
   }
 
+  // A debug block that properly fetches the events of the association if they were modified
+  // or created this session as the events are not updated in the association object
   var events by remember { mutableStateOf<List<Event>>(emptyList()) }
-  LaunchedEffect(Unit) {
-    associationViewModel.getEventsForAssociation(association!!, { events = it })
-  }
+  //  LaunchedEffect(Unit) {
+  //    associationViewModel.getEventsForAssociation(association!!, { events = it })
+  //  }
 
   // Add spacedBy to the horizontalArrangement
   Column(
@@ -432,6 +433,7 @@ private fun AssociationMembers(members: List<User>, onMemberClick: (User) -> Uni
  * @param navigationAction (NavigationAction) : The navigation actions of the screen
  * @param association (Association) : The association currently displayed
  * @param userViewModel (UserViewModel) : The user view model
+ * @param eventViewModel (EventViewModel) : The event view model
  */
 @Composable
 private fun AssociationEvents(
@@ -444,6 +446,8 @@ private fun AssociationEvents(
   val context = LocalContext.current
 
   var isSeeMoreClicked by remember { mutableStateOf(false) }
+
+  val events by association.events.list.collectAsState()
 
   // To be changed when we have a functional admin system
   var isAdmin by remember { mutableStateOf(true) }

--- a/app/src/main/java/com/android/unio/ui/event/EventCard.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCard.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,7 +16,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.IconButton
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.FavoriteBorder
 import androidx.compose.material3.Icon
@@ -59,7 +62,8 @@ fun EventCard(
     navigationAction: NavigationAction,
     event: Event,
     userViewModel: UserViewModel,
-    eventViewModel: EventViewModel
+    eventViewModel: EventViewModel,
+    shouldBeEditable: Boolean = false // To be changed in the future once permissions are implemented
 ) {
   val user by userViewModel.user.collectAsState()
   val associations by event.organisers.list.collectAsState()
@@ -87,7 +91,13 @@ fun EventCard(
           user!!.savedEvents.add(event.uid)
         }
         userViewModel.updateUserDebounced(user!!)
-      })
+      },
+        onClickEditButton = {
+            eventViewModel.selectEvent(event.uid)
+            navigationAction.navigateTo(Screen.EVENT_CREATION) //TODO change to event edit
+        },
+        shouldBeEditable = shouldBeEditable
+  )
 }
 
 @Composable
@@ -96,7 +106,9 @@ fun EventCardScaffold(
     organisers: List<Association>,
     isSaved: Boolean,
     onClickEventCard: () -> Unit,
-    onClickSaveButton: () -> Unit
+    onClickSaveButton: () -> Unit,
+    onClickEditButton: () -> Unit,
+    shouldBeEditable: Boolean
 ) {
   val context = LocalContext.current
   Column(
@@ -125,26 +137,49 @@ fun EventCardScaffold(
 
           // Save button icon on the top right corner of the image, allows the user to save/unsave
           // the event
+            Row(modifier = Modifier.align(Alignment.TopEnd).padding(2.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+                if (shouldBeEditable) {
+                    IconButton(
+                        modifier = Modifier
+                            .size(28.dp)
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(MaterialTheme.colorScheme.inversePrimary)
+                            .padding(4.dp),
+                        onClick = {
+                            onClickEditButton()
+                        }
 
-          Box(
-              modifier =
-                  Modifier.size(28.dp)
-                      .clip(RoundedCornerShape(14.dp))
-                      .background(MaterialTheme.colorScheme.inversePrimary)
-                      .align(Alignment.TopEnd)
-                      .clickable { onClickSaveButton() }
-                      .padding(4.dp)) {
-                Icon(
-                    imageVector =
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Edit,
+                            contentDescription = "editassociation",
+                            tint = Color.White
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.width(2.dp))
+
+                Box(
+                    modifier =
+                    Modifier.size(28.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(MaterialTheme.colorScheme.inversePrimary)
+                        .clickable { onClickSaveButton() }
+                        .padding(4.dp)) {
+                    Icon(
+                        imageVector =
                         if (isSaved) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
-                    contentDescription =
+                        contentDescription =
                         if (isSaved)
                             context.getString(R.string.event_card_content_description_saved_event)
                         else
                             context.getString(
-                                R.string.event_card_content_description_not_saved_event),
-                    tint = if (isSaved) Color.Red else Color.White)
-              }
+                                R.string.event_card_content_description_not_saved_event
+                            ),
+                        tint = if (isSaved) Color.Red else Color.White
+                    )
+                }
+            }
         }
 
         // Event details section, including title, type, location, and time

--- a/app/src/main/java/com/android/unio/ui/event/EventCard.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCard.kt
@@ -16,12 +16,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.FavoriteBorder
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -63,7 +63,8 @@ fun EventCard(
     event: Event,
     userViewModel: UserViewModel,
     eventViewModel: EventViewModel,
-    shouldBeEditable: Boolean = false // To be changed in the future once permissions are implemented
+    shouldBeEditable: Boolean =
+        false // To be changed in the future once permissions are implemented
 ) {
   val user by userViewModel.user.collectAsState()
   val associations by event.organisers.list.collectAsState()
@@ -92,12 +93,11 @@ fun EventCard(
         }
         userViewModel.updateUserDebounced(user!!)
       },
-        onClickEditButton = {
-            eventViewModel.selectEvent(event.uid)
-            navigationAction.navigateTo(Screen.EVENT_CREATION) //TODO change to event edit
-        },
-        shouldBeEditable = shouldBeEditable
-  )
+      onClickEditButton = {
+        eventViewModel.selectEvent(event.uid)
+        navigationAction.navigateTo(Screen.EDIT_EVENT)
+      },
+      shouldBeEditable = shouldBeEditable)
 }
 
 @Composable
@@ -137,49 +137,45 @@ fun EventCardScaffold(
 
           // Save button icon on the top right corner of the image, allows the user to save/unsave
           // the event
-            Row(modifier = Modifier.align(Alignment.TopEnd).padding(2.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+          Row(
+              modifier = Modifier.align(Alignment.TopEnd).padding(2.dp),
+              horizontalArrangement = Arrangement.SpaceBetween) {
                 if (shouldBeEditable) {
-                    IconButton(
-                        modifier = Modifier
-                            .size(28.dp)
-                            .clip(RoundedCornerShape(14.dp))
-                            .background(MaterialTheme.colorScheme.inversePrimary)
-                            .padding(4.dp),
-                        onClick = {
-                            onClickEditButton()
-                        }
-
-                    ) {
+                  IconButton(
+                      modifier =
+                          Modifier.size(28.dp)
+                              .clip(RoundedCornerShape(14.dp))
+                              .background(MaterialTheme.colorScheme.inversePrimary)
+                              .padding(4.dp),
+                      onClick = { onClickEditButton() }) {
                         Icon(
                             imageVector = Icons.Outlined.Edit,
                             contentDescription = "editassociation",
-                            tint = Color.White
-                        )
-                    }
+                            tint = Color.White)
+                      }
                 }
                 Spacer(modifier = Modifier.width(2.dp))
 
                 Box(
                     modifier =
-                    Modifier.size(28.dp)
-                        .clip(RoundedCornerShape(14.dp))
-                        .background(MaterialTheme.colorScheme.inversePrimary)
-                        .clickable { onClickSaveButton() }
-                        .padding(4.dp)) {
-                    Icon(
-                        imageVector =
-                        if (isSaved) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
-                        contentDescription =
-                        if (isSaved)
-                            context.getString(R.string.event_card_content_description_saved_event)
-                        else
-                            context.getString(
-                                R.string.event_card_content_description_not_saved_event
-                            ),
-                        tint = if (isSaved) Color.Red else Color.White
-                    )
-                }
-            }
+                        Modifier.size(28.dp)
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(MaterialTheme.colorScheme.inversePrimary)
+                            .clickable { onClickSaveButton() }
+                            .padding(4.dp)) {
+                      Icon(
+                          imageVector =
+                              if (isSaved) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                          contentDescription =
+                              if (isSaved)
+                                  context.getString(
+                                      R.string.event_card_content_description_saved_event)
+                              else
+                                  context.getString(
+                                      R.string.event_card_content_description_not_saved_event),
+                          tint = if (isSaved) Color.Red else Color.White)
+                    }
+              }
         }
 
         // Event details section, including title, type, location, and time

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -83,7 +83,8 @@ fun EventEditScreen(
   var coauthorsAndBoolean =
       associationViewModel.associations.collectAsState().value.map {
         it to
-            (if (eventToEdit.organisers.contains(it.uid)) mutableStateOf(true) else mutableStateOf(false))
+            (if (eventToEdit.organisers.contains(it.uid)) mutableStateOf(true)
+            else mutableStateOf(false))
       }
 
   var taggedAndBoolean =

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -2,54 +2,28 @@ package com.android.unio.ui.event
 
 import android.net.Uri
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TimeInput
-import androidx.compose.material3.rememberDatePickerState
-import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -58,15 +32,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.pointer.PointerEventPass
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
+import androidx.core.net.toUri
 import com.android.unio.R
 import com.android.unio.model.association.Association
 import com.android.unio.model.association.AssociationViewModel
@@ -75,19 +44,14 @@ import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.firestore.firestoreReferenceListWith
 import com.android.unio.model.map.Location
 import com.android.unio.model.search.SearchViewModel
-import com.android.unio.model.strings.FormatStrings.DAY_MONTH_YEAR_FORMAT
-import com.android.unio.model.strings.FormatStrings.HOUR_MINUTE_FORMAT
 import com.android.unio.model.strings.test_tags.EventCreationTestTags
 import com.android.unio.ui.event.overlay.AssociationsOverlay
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.theme.AppTypography
 import com.google.firebase.Timestamp
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
 @Composable
-fun EventCreationScreen(
+fun EventEditScreen(
     navigationAction: NavigationAction,
     searchViewModel: SearchViewModel,
     associationViewModel: AssociationViewModel,
@@ -98,20 +62,29 @@ fun EventCreationScreen(
   var showCoauthorsOverlay by remember { mutableStateOf(false) }
   var showTaggedOverlay by remember { mutableStateOf(false) }
 
-  var name by remember { mutableStateOf("") }
-  var shortDescription by remember { mutableStateOf("") }
-  var longDescription by remember { mutableStateOf("") }
+  var event = remember { eventViewModel.selectedEvent.value!! }
+
+  var name by remember { mutableStateOf(event.title) }
+  var shortDescription by remember { mutableStateOf(event.catchyDescription) }
+  var longDescription by remember { mutableStateOf(event.description) }
 
   var coauthorsAndBoolean =
-      associationViewModel.associations.collectAsState().value.map { it to mutableStateOf(false) }
+      associationViewModel.associations.collectAsState().value.map {
+        it to
+            (if (event.organisers.contains(it.uid)) mutableStateOf(true) else mutableStateOf(false))
+      }
 
   var taggedAndBoolean =
-      associationViewModel.associations.collectAsState().value.map { it to mutableStateOf(false) }
+      associationViewModel.associations.collectAsState().value.map {
+        it to
+            (if (event.taggedAssociations.contains(it.uid)) mutableStateOf(true)
+            else mutableStateOf(false))
+      }
 
-  var startTimestamp: Timestamp? by remember { mutableStateOf(null) }
-  var endTimestamp: Timestamp? by remember { mutableStateOf(null) }
+  var startTimestamp: Timestamp? by remember { mutableStateOf(event.startDate) }
+  var endTimestamp: Timestamp? by remember { mutableStateOf(event.endDate) }
 
-  val eventBannerUri = remember { mutableStateOf<Uri>(Uri.EMPTY) }
+  val eventBannerUri = remember { mutableStateOf<Uri>(event.image.toUri()) }
 
   Scaffold(modifier = Modifier.testTag(EventCreationTestTags.SCREEN)) { padding ->
     Column(
@@ -230,10 +203,11 @@ fun EventCreationScreen(
                       eventBannerUri.value != Uri.EMPTY,
               onClick = {
                 val inputStream = context.contentResolver.openInputStream(eventBannerUri.value)!!
+                  //TODO remove the event by uid first before adding the new one
                 eventViewModel.addEvent(
                     inputStream,
                     Event(
-                        uid = "", // This gets overwritten by eventViewModel.addEvent
+                        uid = event.uid,
                         title = name,
                         organisers =
                             Association.firestoreReferenceListWith(
@@ -292,228 +266,4 @@ fun EventCreationScreen(
           }
         }
   }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-fun AssociationChips(
-    associations: List<Pair<Association, MutableState<Boolean>>>,
-) {
-  val context = LocalContext.current
-  FlowRow {
-    associations.forEach { (association, selected) ->
-      if (selected.value) {
-        InputChip(
-            label = { Text(association.name) },
-            onClick = {},
-            selected = selected.value,
-            avatar = {
-              Icon(
-                  Icons.Default.Close,
-                  contentDescription = context.getString(R.string.associations_overlay_remove),
-                  modifier = Modifier.clickable { selected.value = !selected.value })
-            })
-      }
-    }
-  }
-}
-
-@Composable
-fun BannerImagePicker(eventBannerUri: MutableState<Uri>) {
-  val context = LocalContext.current
-
-  val pickMedia =
-      rememberLauncherForActivityResult(
-          contract = ActivityResultContracts.PickVisualMedia(),
-          onResult = { uri: Uri? -> uri?.let { eventBannerUri.value = it } })
-
-  Box(
-      modifier =
-          Modifier.size(390.dp, 100.dp)
-              .clip(RoundedCornerShape(4.dp))
-              .testTag(EventCreationTestTags.EVENT_IMAGE)
-              .clickable {
-                pickMedia.launch(
-                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
-              },
-      contentAlignment = Alignment.Center) {
-        if (eventBannerUri.value != Uri.EMPTY) {
-          Image(
-              painter = rememberAsyncImagePainter(eventBannerUri.value),
-              contentDescription =
-                  context.getString(R.string.event_creation_selected_image_description),
-              modifier = Modifier.fillMaxSize(),
-              contentScale = ContentScale.Crop)
-        } else {
-          Image(
-              painter = painterResource(id = R.drawable.adec),
-              contentDescription =
-                  context.getString(R.string.event_creation_placeholder_image_description),
-              modifier = Modifier.fillMaxSize(),
-              contentScale = ContentScale.Crop)
-          Text(
-              text = context.getString(R.string.event_creation_image_label),
-              modifier = Modifier.align(Alignment.Center))
-        }
-      }
-}
-
-@Composable
-fun DateAndTimePicker(
-    dateString: String,
-    timeString: String,
-    modifier: Modifier,
-    onTimestamp: (Timestamp) -> Unit
-) {
-  var isDatePickerVisible by remember { mutableStateOf(false) }
-  var isTimePickerVisible by remember { mutableStateOf(false) }
-  var selectedDate by remember { mutableStateOf<Long?>(null) }
-  var selectedTime by remember { mutableStateOf<Long?>(null) }
-  val context = LocalContext.current
-
-  Row(
-      modifier.fillMaxWidth(),
-  ) {
-    OutlinedTextField(
-        modifier =
-            Modifier.weight(1f).pointerInput(Unit) {
-              awaitEachGesture {
-                // Modifier.clickable doesn't work for text fields, so we use Modifier.pointerInput
-                // in the Initial pass to observe events before the text field consumes them
-                // in the Main pass.
-                awaitFirstDown(pass = PointerEventPass.Initial)
-                val upEvent = waitForUpOrCancellation(pass = PointerEventPass.Initial)
-                if (upEvent != null) {
-                  isDatePickerVisible = true
-                }
-              }
-            },
-        value = selectedDate?.let { convertMillisToDate(it) } ?: "",
-        readOnly = true,
-        onValueChange = {},
-        trailingIcon = { Icon(Icons.Default.DateRange, contentDescription = "Select date") },
-        placeholder = { Text(context.getString(R.string.event_creation_placeholder_date_input)) },
-        label = { Text(dateString) })
-    Spacer(modifier = Modifier.weight(0.05f))
-    OutlinedTextField(
-        modifier =
-            Modifier.weight(1f).pointerInput(Unit) {
-              awaitEachGesture {
-                // Modifier.clickable doesn't work for text fields, so we use Modifier.pointerInput
-                // in the Initial pass to observe events before the text field consumes them
-                // in the Main pass.
-                awaitFirstDown(pass = PointerEventPass.Initial)
-                val upEvent = waitForUpOrCancellation(pass = PointerEventPass.Initial)
-                if (upEvent != null) {
-                  isTimePickerVisible = true
-                }
-              }
-            },
-        value = selectedTime?.let { convertMillisToTime(it) } ?: "",
-        readOnly = true,
-        onValueChange = {},
-        trailingIcon = { Icon(Icons.Default.AccessTime, contentDescription = "Select date") },
-        placeholder = { Text(context.getString(R.string.event_creation_placeholder_time_input)) },
-        label = { Text(timeString) })
-  }
-
-  if (isDatePickerVisible) {
-    DatePickerModal(
-        onDateSelected = {
-          selectedDate = it
-          isDatePickerVisible = false
-        },
-        onDismiss = { isDatePickerVisible = false })
-  }
-
-  if (isTimePickerVisible) {
-    TimePickerModal(
-        onTimeSelected = {
-          selectedTime = it
-          isTimePickerVisible = false
-        },
-        onDismiss = { isTimePickerVisible = false })
-  }
-
-  if (selectedDate != null && selectedTime != null) {
-    onTimestamp(Timestamp(Date(selectedDate!! + selectedTime!!)))
-  }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun DatePickerModal(onDateSelected: (Long?) -> Unit, onDismiss: () -> Unit) {
-  val datePickerState = rememberDatePickerState()
-  val context = LocalContext.current
-
-  DatePickerDialog(
-      onDismissRequest = onDismiss,
-      confirmButton = {
-        TextButton(
-            onClick = {
-              onDateSelected(datePickerState.selectedDateMillis)
-              onDismiss()
-            }) {
-              Text(context.getString(R.string.event_creation_dialog_ok))
-            }
-      },
-      dismissButton = {
-        TextButton(onClick = onDismiss) {
-          Text(context.getString(R.string.event_creation_dialog_cancel))
-        }
-      }) {
-        DatePicker(state = datePickerState)
-      }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun TimePickerModal(onTimeSelected: (Long?) -> Unit, onDismiss: () -> Unit) {
-  val timePickerState = rememberTimePickerState(is24Hour = true)
-
-  TimePickerDialog(
-      onDismiss = onDismiss,
-      onConfirm = {
-        onTimeSelected(
-            timePickerState.hour * 60 * 60 * 1000L - 3600000 + timePickerState.minute * 60 * 1000L)
-        onDismiss()
-      }) {
-        TimeInput(state = timePickerState)
-      }
-}
-
-/**
- * A Dialog that is the analog of the DatePickerDialog, but for TimePicker as it currently does not
- * exist in the Material3 library.
- */
-@Composable
-fun TimePickerDialog(
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
-    content: @Composable () -> Unit
-) {
-  val context = LocalContext.current
-  AlertDialog(
-      onDismissRequest = onDismiss,
-      dismissButton = {
-        TextButton(onClick = { onDismiss() }) {
-          Text(context.getString(R.string.event_creation_dialog_cancel))
-        }
-      },
-      confirmButton = {
-        TextButton(onClick = { onConfirm() }) {
-          Text(context.getString(R.string.event_creation_dialog_ok))
-        }
-      },
-      text = { content() })
-}
-
-fun convertMillisToDate(millis: Long): String {
-  val formatter = SimpleDateFormat(DAY_MONTH_YEAR_FORMAT, Locale.getDefault())
-  return formatter.format(Date(millis))
-}
-
-fun convertMillisToTime(millis: Long): String {
-  val formatter = SimpleDateFormat(HOUR_MINUTE_FORMAT, Locale.getDefault())
-  return formatter.format(Date(millis))
 }

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -203,8 +203,7 @@ fun EventEditScreen(
                       eventBannerUri.value != Uri.EMPTY,
               onClick = {
                 val inputStream = context.contentResolver.openInputStream(eventBannerUri.value)!!
-                  //TODO remove the event by uid first before adding the new one
-                eventViewModel.addEvent(
+                eventViewModel.updateEvent(
                     inputStream,
                     Event(
                         uid = event.uid,

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -209,7 +209,7 @@ fun EventEditScreen(
               horizontalArrangement = Arrangement.SpaceEvenly,
               verticalAlignment = Alignment.CenterVertically) {
                 Button(
-                     modifier = Modifier.testTag(EventEditTestTags.DELETE_BUTTON),
+                    modifier = Modifier.testTag(EventEditTestTags.DELETE_BUTTON),
                     colors =
                         ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.error),

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -53,6 +53,15 @@ import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.theme.AppTypography
 import com.google.firebase.Timestamp
 
+/**
+ * Composable function that displays the event edit screen. It functions similarly to the Event
+ * Creation screen, but pre-populates the fields with the event's current data.
+ *
+ * @param navigationAction The navigation actions to be performed.
+ * @param searchViewModel The [SearchViewModel] that provides search functionality.
+ * @param associationViewModel The [AssociationViewModel] that provides association data.
+ * @param eventViewModel The [EventViewModel] that provides event data.
+ */
 @Composable
 fun EventEditScreen(
     navigationAction: NavigationAction,
@@ -65,29 +74,29 @@ fun EventEditScreen(
   var showCoauthorsOverlay by remember { mutableStateOf(false) }
   var showTaggedOverlay by remember { mutableStateOf(false) }
 
-  var event = remember { eventViewModel.selectedEvent.value!! }
+  val eventToEdit = remember { eventViewModel.selectedEvent.value!! }
 
-  var name by remember { mutableStateOf(event.title) }
-  var shortDescription by remember { mutableStateOf(event.catchyDescription) }
-  var longDescription by remember { mutableStateOf(event.description) }
+  var name by remember { mutableStateOf(eventToEdit.title) }
+  var shortDescription by remember { mutableStateOf(eventToEdit.catchyDescription) }
+  var longDescription by remember { mutableStateOf(eventToEdit.description) }
 
   var coauthorsAndBoolean =
       associationViewModel.associations.collectAsState().value.map {
         it to
-            (if (event.organisers.contains(it.uid)) mutableStateOf(true) else mutableStateOf(false))
+            (if (eventToEdit.organisers.contains(it.uid)) mutableStateOf(true) else mutableStateOf(false))
       }
 
   var taggedAndBoolean =
       associationViewModel.associations.collectAsState().value.map {
         it to
-            (if (event.taggedAssociations.contains(it.uid)) mutableStateOf(true)
+            (if (eventToEdit.taggedAssociations.contains(it.uid)) mutableStateOf(true)
             else mutableStateOf(false))
       }
 
-  var startTimestamp: Timestamp? by remember { mutableStateOf(event.startDate) }
-  var endTimestamp: Timestamp? by remember { mutableStateOf(event.endDate) }
+  var startTimestamp: Timestamp? by remember { mutableStateOf(eventToEdit.startDate) }
+  var endTimestamp: Timestamp? by remember { mutableStateOf(eventToEdit.endDate) }
 
-  val eventBannerUri = remember { mutableStateOf<Uri>(event.image.toUri()) }
+  val eventBannerUri = remember { mutableStateOf<Uri>(eventToEdit.image.toUri()) }
 
   Scaffold(modifier = Modifier.testTag(EventCreationTestTags.SCREEN)) { padding ->
     Column(
@@ -206,7 +215,7 @@ fun EventEditScreen(
                     onClick = {
                       // TODO add a dialog to confirm deletion
                       eventViewModel.deleteEvent(
-                          event.uid,
+                          eventToEdit.uid,
                           onSuccess = { navigationAction.goBack() },
                           onFailure = {
                             Toast.makeText(
@@ -235,7 +244,7 @@ fun EventEditScreen(
                     onClick = {
                       val updatedEvent =
                           Event(
-                              uid = event.uid,
+                              uid = eventToEdit.uid,
                               title = name,
                               organisers =
                                   Association.firestoreReferenceListWith(

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -45,7 +45,7 @@ import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.firestore.firestoreReferenceListWith
 import com.android.unio.model.map.Location
 import com.android.unio.model.search.SearchViewModel
-import com.android.unio.model.strings.test_tags.EventCreationTestTags
+import com.android.unio.model.strings.test_tags.EventEditTestTags
 import com.android.unio.model.user.ImageUriType
 import com.android.unio.model.user.checkImageUri
 import com.android.unio.ui.event.overlay.AssociationsOverlay
@@ -99,7 +99,7 @@ fun EventEditScreen(
 
   val eventBannerUri = remember { mutableStateOf<Uri>(eventToEdit.image.toUri()) }
 
-  Scaffold(modifier = Modifier.testTag(EventCreationTestTags.SCREEN)) { padding ->
+  Scaffold(modifier = Modifier.testTag(EventEditTestTags.SCREEN)) { padding ->
     Column(
         modifier =
             Modifier.padding(padding).padding(20.dp).fillMaxWidth().verticalScroll(scrollState),
@@ -115,19 +115,19 @@ fun EventEditScreen(
                       contentDescription = context.getString(R.string.event_creation_cancel_button))
                 }
                 Text(
-                    context.getString(R.string.event_creation_title),
+                    context.getString(R.string.event_edit_title) + " " + eventToEdit.title,
                     style = AppTypography.headlineSmall,
-                    modifier = Modifier.testTag(EventCreationTestTags.TITLE))
+                    modifier = Modifier.testTag(EventEditTestTags.TITLE))
               }
 
           OutlinedTextField(
-              modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.EVENT_TITLE),
+              modifier = Modifier.fillMaxWidth().testTag(EventEditTestTags.EVENT_TITLE),
               value = name,
               onValueChange = { name = it },
               label = { Text(context.getString(R.string.event_creation_name_label)) })
 
           OutlinedTextField(
-              modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.SHORT_DESCRIPTION),
+              modifier = Modifier.fillMaxWidth().testTag(EventEditTestTags.SHORT_DESCRIPTION),
               value = shortDescription,
               onValueChange = { shortDescription = it },
               label = { Text(context.getString(R.string.event_creation_short_description_label)) })
@@ -135,7 +135,7 @@ fun EventEditScreen(
           BannerImagePicker(eventBannerUri)
 
           OutlinedButton(
-              modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.COAUTHORS),
+              modifier = Modifier.fillMaxWidth().testTag(EventEditTestTags.COAUTHORS),
               onClick = { showCoauthorsOverlay = true }) {
                 Icon(
                     Icons.Default.Add,
@@ -147,7 +147,7 @@ fun EventEditScreen(
           AssociationChips(coauthorsAndBoolean)
 
           OutlinedButton(
-              modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.TAGGED_ASSOCIATIONS),
+              modifier = Modifier.fillMaxWidth().testTag(EventEditTestTags.TAGGED_ASSOCIATIONS),
               onClick = { showTaggedOverlay = true }) {
                 Icon(
                     Icons.Default.Add,
@@ -159,7 +159,7 @@ fun EventEditScreen(
           AssociationChips(taggedAndBoolean)
 
           OutlinedTextField(
-              modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.DESCRIPTION),
+              modifier = Modifier.fillMaxWidth().testTag(EventEditTestTags.DESCRIPTION),
               value = longDescription,
               onValueChange = { longDescription = it },
               label = { Text(context.getString(R.string.event_creation_description_label)) })
@@ -167,34 +167,34 @@ fun EventEditScreen(
           DateAndTimePicker(
               context.getString(R.string.event_creation_startdate_label),
               context.getString(R.string.event_creation_starttime_label),
-              modifier = Modifier.testTag(EventCreationTestTags.START_TIME)) {
+              modifier = Modifier.testTag(EventEditTestTags.START_TIME)) {
                 startTimestamp = it
               }
 
           DateAndTimePicker(
               context.getString(R.string.event_creation_enddate_label),
               context.getString(R.string.event_creation_endtime_label),
-              modifier = Modifier.testTag(EventCreationTestTags.END_TIME)) {
+              modifier = Modifier.testTag(EventEditTestTags.END_TIME)) {
                 endTimestamp = it
               }
           if (startTimestamp != null && endTimestamp != null) {
             if (startTimestamp!! > endTimestamp!!) {
               Text(
                   text = context.getString(R.string.event_creation_end_before_start),
-                  modifier = Modifier.testTag(EventCreationTestTags.ERROR_TEXT1),
+                  modifier = Modifier.testTag(EventEditTestTags.ERROR_TEXT1),
                   color = MaterialTheme.colorScheme.error)
             }
             if (startTimestamp!! == endTimestamp!!) {
               Text(
                   text = context.getString(R.string.event_creation_end_equals_start),
-                  modifier = Modifier.testTag(EventCreationTestTags.ERROR_TEXT2),
+                  modifier = Modifier.testTag(EventEditTestTags.ERROR_TEXT2),
                   color = MaterialTheme.colorScheme.error)
             }
           }
 
           OutlinedTextField(
               modifier =
-                  Modifier.fillMaxWidth().testTag(EventCreationTestTags.LOCATION).clickable {
+                  Modifier.fillMaxWidth().testTag(EventEditTestTags.LOCATION).clickable {
                     Toast.makeText(context, "Location is not implemented yet", Toast.LENGTH_SHORT)
                         .show()
                   },
@@ -209,7 +209,7 @@ fun EventEditScreen(
               horizontalArrangement = Arrangement.SpaceEvenly,
               verticalAlignment = Alignment.CenterVertically) {
                 Button(
-                    // modifier = Modifier.testTag(EventCreationTestTags.DELETE_BUTTON),
+                     modifier = Modifier.testTag(EventEditTestTags.DELETE_BUTTON),
                     colors =
                         ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.error),
@@ -221,19 +221,16 @@ fun EventEditScreen(
                           onFailure = {
                             Toast.makeText(
                                     context,
-                                    context.getString(R.string.event_creation_failed),
+                                    context.getString(R.string.event_edit_failed),
                                     Toast.LENGTH_SHORT)
                                 .show()
                           })
                     }) {
-                      Text(
-                          "Delete"
-                          // context.getString(R.string.event_creation_delete_button)
-                          )
+                      Text(context.getString(R.string.event_edit_delete_button))
                     }
 
                 Button(
-                    modifier = Modifier.testTag(EventCreationTestTags.SAVE_BUTTON),
+                    modifier = Modifier.testTag(EventEditTestTags.SAVE_BUTTON),
                     enabled =
                         name.isNotEmpty() &&
                             shortDescription.isNotEmpty() &&
@@ -295,10 +292,7 @@ fun EventEditScreen(
                             })
                       }
                     }) {
-                      Text(
-                          "Save"
-                          // context.getString(R.string.event_creation_save_button)
-                          )
+                      Text(context.getString(R.string.event_edit_save_button))
                     }
               }
           Spacer(modifier = Modifier.width(10.dp))

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -173,6 +173,12 @@
     <string name="event_creation_end_equals_start">L\'heure de fin ne peut pas être l\'heure de début</string>
     <string name="event_creation_failed">Echec lors de la création</string>
 
+    <!-- Event Edit Strings -->
+    <string name="event_edit_title">Modifier </string>
+    <string name="event_edit_delete_button">Supprimer</string>
+    <string name="event_edit_failed">Echec lors de la modification</string>
+    <string name="event_edit_save_button">Sauvegarder</string>
+
     <!-- Associations Overlay Strings -->
     <string name="associations_overlay_coauthors_title" translatable="true">Co-organisateurs</string>
     <string name="associations_overlay_coauthors_description" translatable="true">Choisir quels associations organisent l\'évènement avec vous</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,11 @@
     <string name="event_creation_end_equals_start">Event cannot start and end at the same time</string>
     <string name="event_creation_failed">Failed to create event</string>
 
+    <!-- Event Edit Strings -->
+    <string name="event_edit_title">Edit </string>
+    <string name="event_edit_delete_button">Delete</string>
+    <string name="event_edit_failed">Failed to edit event</string>
+    <string name="event_edit_save_button">Save</string>
 
     <!-- Associations Overlay Strings -->
     <string name="associations_overlay_coauthors_title" translatable="true">Coauthors</string>

--- a/app/src/test/java/com/android/unio/model/event/EventViewModelTest.kt
+++ b/app/src/test/java/com/android/unio/model/event/EventViewModelTest.kt
@@ -2,6 +2,7 @@ package com.android.unio.model.event
 
 import androidx.test.core.app.ApplicationProvider
 import com.android.unio.mocks.event.MockEvent
+import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
 import com.google.firebase.FirebaseApp
 import com.google.firebase.Timestamp
@@ -34,6 +35,7 @@ class EventViewModelTest {
   @Mock private lateinit var inputStream: InputStream
 
   @MockK lateinit var imageRepository: ImageRepositoryFirebaseStorage
+  @MockK private lateinit var associationRepositoryFirestore: AssociationRepositoryFirestore
 
   private lateinit var eventViewModel: EventViewModel
 
@@ -68,7 +70,7 @@ class EventViewModelTest {
           onSuccess("url")
         }
 
-    eventViewModel = EventViewModel(repository, imageRepository)
+    eventViewModel = EventViewModel(repository, imageRepository, associationRepositoryFirestore)
   }
 
   @Test


### PR DESCRIPTION
This PR adds on the events of the association profile page the ability to edit or delete an event.  
There are currently no tests and a there is a synchronization problem between the AssociationViewModel and the firestore database when creation, editing or deleting an event, which is why this PR is currently a draft.