### PR TITLE
Fix/edit profile offline

### DIFF
--- a/app/src/androidTest/java/com/android/unio/components/user/UserProfileEditionTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/user/UserProfileEditionTest.kt
@@ -1,5 +1,7 @@
 package com.android.unio.components.user
 
+import android.net.ConnectivityManager
+import android.net.Network
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -7,18 +9,26 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.getSystemService
 import com.android.unio.TearDown
 import com.android.unio.addNewUserSocial
 import com.android.unio.mocks.user.MockUser
 import com.android.unio.model.strings.test_tags.InterestsOverlayTestTags
 import com.android.unio.model.strings.test_tags.SocialsOverlayTestTags
 import com.android.unio.model.strings.test_tags.UserEditionTestTags
+import com.android.unio.model.user.User
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.navigation.Screen
 import com.android.unio.ui.user.UserProfileEditionScreenContent
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -32,6 +42,11 @@ class UserProfileEditionTest : TearDown() {
   @get:Rule val composeTestRule = createComposeRule()
   @get:Rule val hiltRule = HiltAndroidRule(this)
 
+  @MockK private lateinit var connectivityManager: ConnectivityManager
+
+  private lateinit var user: User
+  private var isOnlineUpdated: Boolean = false
+
   @Before
   fun setUp() {
     MockKAnnotations.init(this, relaxed = true)
@@ -40,16 +55,90 @@ class UserProfileEditionTest : TearDown() {
     navigationAction = mock(NavigationAction::class.java)
     `when`(navigationAction.getCurrentRoute()).thenReturn(Screen.EDIT_PROFILE)
 
-    val user = MockUser.createMockUser(interests = emptyList(), profilePicture = "")
+    user = MockUser.createMockUser(interests = emptyList(), profilePicture = "")
+
+    val onOfflineChange = { newUser: User ->
+      user = newUser
+      isOnlineUpdated = false
+    }
+
+    val onOnlineChange = { newUser: User ->
+      user = newUser
+      isOnlineUpdated = true
+    }
+
+    mockkStatic(Network::class)
+    mockkStatic(ContextCompat::class)
+    every { getSystemService(any(), ConnectivityManager::class.java) } returns connectivityManager
 
     composeTestRule.setContent {
       UserProfileEditionScreenContent(
-          user, onDiscardChanges = { navigationAction.goBack() }, { uri, method -> method("") }, {})
+          user,
+          { navigationAction.goBack() },
+          { uri, method -> method("") },
+          onOnlineChange,
+          onOfflineChange)
     }
   }
 
   @Test
+  fun testUpdateUserOffline() {
+    every { connectivityManager?.activeNetwork } returns null
+
+    composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performClick()
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD)
+        .performTextInput(UserUpdate.FIRST_NAME)
+    composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performClick()
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD)
+        .performTextInput(UserUpdate.LAST_NAME)
+    composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performClick()
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD)
+        .performTextInput(UserUpdate.BIOGRAPHY)
+    composeTestRule.onNodeWithTag(UserEditionTestTags.SAVE_BUTTON).performClick()
+
+    assert(user.firstName == UserUpdate.FIRST_NAME)
+    assert(user.lastName == UserUpdate.LAST_NAME)
+    assert(user.biography == UserUpdate.BIOGRAPHY)
+    assert(!isOnlineUpdated)
+  }
+
+  @Test
+  fun testUpdateUserOnline() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
+    composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performClick()
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD)
+        .performTextInput(UserUpdate.FIRST_NAME)
+    composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performClick()
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD)
+        .performTextInput(UserUpdate.LAST_NAME)
+    composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performClick()
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD)
+        .performTextInput(UserUpdate.BIOGRAPHY)
+    composeTestRule.onNodeWithTag(UserEditionTestTags.SAVE_BUTTON).performClick()
+
+    assert(user.firstName == UserUpdate.FIRST_NAME)
+    assert(user.lastName == UserUpdate.LAST_NAME)
+    assert(user.biography == UserUpdate.BIOGRAPHY)
+    assert(isOnlineUpdated)
+  }
+
+  @Test
   fun testEverythingIsDisplayed() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule.onNodeWithTag(UserEditionTestTags.DISCARD_TEXT).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT, useUnmergedTree = true)
@@ -66,6 +155,8 @@ class UserProfileEditionTest : TearDown() {
 
   @Test
   fun testInterestsButtonWorksCorrectly() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.INTERESTS_BUTTON)
         .performScrollTo()
@@ -75,6 +166,8 @@ class UserProfileEditionTest : TearDown() {
 
   @Test
   fun testSocialsButtonWorksCorrectly() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.SOCIALS_BUTTON)
         .performScrollTo()
@@ -84,6 +177,8 @@ class UserProfileEditionTest : TearDown() {
 
   @Test
   fun testAddingInterestsCorrectlyModifiesTheFlowRow() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.INTERESTS_BUTTON)
         .performScrollTo()
@@ -104,6 +199,8 @@ class UserProfileEditionTest : TearDown() {
 
   @Test
   fun testAddingSocialsCorrectlyModifiesTheFlowRow() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.SOCIALS_BUTTON)
         .performScrollTo()
@@ -121,6 +218,8 @@ class UserProfileEditionTest : TearDown() {
 
   @Test
   fun testCorrectlyExitsInterestOverlayScreen() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.INTERESTS_BUTTON)
         .performScrollTo()
@@ -131,6 +230,8 @@ class UserProfileEditionTest : TearDown() {
 
   @Test
   fun testCorrectlyDisplaysErrorWhenFirstNameIsEmpty() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
     composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performTextClearance()
 
@@ -141,5 +242,11 @@ class UserProfileEditionTest : TearDown() {
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.LAST_NAME_ERROR_TEXT, useUnmergedTree = true)
         .assertExists()
+  }
+
+  object UserUpdate {
+    const val FIRST_NAME = "Johnny"
+    const val LAST_NAME = "Däpp"
+    const val BIOGRAPHY = "Ich bin ein Testbenutzer"
   }
 }

--- a/app/src/androidTest/java/com/android/unio/components/user/UserProfileEditionTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/user/UserProfileEditionTest.kt
@@ -14,6 +14,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.getSystemService
 import com.android.unio.TearDown
 import com.android.unio.addNewUserSocial
+import com.android.unio.assertDisplayComponentInScroll
 import com.android.unio.mocks.user.MockUser
 import com.android.unio.model.strings.test_tags.InterestsOverlayTestTags
 import com.android.unio.model.strings.test_tags.SocialsOverlayTestTags
@@ -85,21 +86,34 @@ class UserProfileEditionTest : TearDown() {
   fun testUpdateUserOffline() {
     every { connectivityManager?.activeNetwork } returns null
 
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD)
+        .assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performClick()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD)
         .performTextInput(UserUpdate.FIRST_NAME)
+
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD)
+        .assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performClick()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD)
         .performTextInput(UserUpdate.LAST_NAME)
+
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD)
+        .assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performClick()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD)
         .performTextInput(UserUpdate.BIOGRAPHY)
+
+    composeTestRule.onNodeWithTag(UserEditionTestTags.SAVE_BUTTON).assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.SAVE_BUTTON).performClick()
 
     assert(user.firstName == UserUpdate.FIRST_NAME)

--- a/app/src/androidTest/java/com/android/unio/components/user/UserProfileEditionTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/user/UserProfileEditionTest.kt
@@ -126,28 +126,34 @@ class UserProfileEditionTest : TearDown() {
   fun testUpdateUserOnline() {
     every { connectivityManager?.activeNetwork } returns mockk<Network>()
 
-      composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).assertDisplayComponentInScroll()
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD)
+        .assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performClick()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD)
         .performTextInput(UserUpdate.FIRST_NAME)
 
-      composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).assertDisplayComponentInScroll()
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD)
+        .assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performClick()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD)
         .performTextInput(UserUpdate.LAST_NAME)
 
-      composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).assertDisplayComponentInScroll()
+    composeTestRule
+        .onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD)
+        .assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performClick()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD)
         .performTextInput(UserUpdate.BIOGRAPHY)
 
-      composeTestRule.onNodeWithTag(UserEditionTestTags.SAVE_BUTTON).assertDisplayComponentInScroll()
+    composeTestRule.onNodeWithTag(UserEditionTestTags.SAVE_BUTTON).assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.SAVE_BUTTON).performClick()
 
     assert(user.firstName == UserUpdate.FIRST_NAME)

--- a/app/src/androidTest/java/com/android/unio/components/user/UserProfileEditionTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/user/UserProfileEditionTest.kt
@@ -126,21 +126,28 @@ class UserProfileEditionTest : TearDown() {
   fun testUpdateUserOnline() {
     every { connectivityManager?.activeNetwork } returns mockk<Network>()
 
+      composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD).performClick()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.FIRST_NAME_TEXT_FIELD)
         .performTextInput(UserUpdate.FIRST_NAME)
+
+      composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD).performClick()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.LAST_NAME_TEXT_FIELD)
         .performTextInput(UserUpdate.LAST_NAME)
+
+      composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD).performClick()
     composeTestRule
         .onNodeWithTag(UserEditionTestTags.BIOGRAPHY_TEXT_FIELD)
         .performTextInput(UserUpdate.BIOGRAPHY)
+
+      composeTestRule.onNodeWithTag(UserEditionTestTags.SAVE_BUTTON).assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserEditionTestTags.SAVE_BUTTON).performClick()
 
     assert(user.firstName == UserUpdate.FIRST_NAME)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -101,6 +101,7 @@
     <string name="user_settings_discard_changes" translatable="true">Annuler vos modifications</string>
     <string name="user_settings_save_changes" translatable="true">Sauvegarder vos modifications</string>
     <string name="user_settings_modified_successfully" translatable="true">Changements correctement modifié</string>
+    <string name="user_settings_modified_offline">Changements enregistrés. Connectez-vous à Internet pour appliquer les changements</string>
 
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,7 @@
     <string name="user_settings_discard_changes" translatable="true">"Discard Changes"</string>
     <string name="user_settings_save_changes" translatable="true">Save changes</string>
     <string name="user_settings_modified_successfully" translatable="true">Changes Successfully modified</string>
+    <string name="user_settings_modified_offline">Change has been saved. Turn online to apply change</string>
 
 
     <!-- EmailVerification Strings -->


### PR DESCRIPTION
- Description modification: This works, but with a bug. When we change the description and press on the save button, nothing seems to happen, e.g. the app doesn't take the user back to the MyProfile screen automatically. However, the description is successfully modified, and I can see my new description when switching screen manually by clicking on the Back button. So it works, but this behavior should be fixed.
- First name and last name modification: works, but with the same buggy behavior as above.
- Social media: works, same as above
- Interests: same as above.

When we gain back connection, it indeed uploads to changes made in offline mode to firebase.