### PR TITLE
Feature/edit with nominatim

### DIFF
--- a/app/src/androidTest/java/com/android/unio/components/event/EventEditTests.kt
+++ b/app/src/androidTest/java/com/android/unio/components/event/EventEditTests.kt
@@ -21,6 +21,8 @@ import com.android.unio.model.event.EventRepositoryFirestore
 import com.android.unio.model.event.EventViewModel
 import com.android.unio.model.follow.ConcurrentAssociationUserRepositoryFirestore
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
+import com.android.unio.model.map.nominatim.NominatimLocationRepository
+import com.android.unio.model.map.nominatim.NominatimLocationSearchViewModel
 import com.android.unio.model.search.SearchRepository
 import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.strings.test_tags.EventEditTestTags
@@ -84,6 +86,10 @@ class EventEditTests : TearDown() {
           location = MockEvent.createMockEvent().location,
           types = listOf(MockEvent.createMockEvent().types.first()))
 
+  @MockK
+  private lateinit var nominatimLocationRepositoryWithoutFunctionality: NominatimLocationRepository
+  private lateinit var nominatimLocationSearchViewModel: NominatimLocationSearchViewModel
+
   @Before
   fun setUp() {
     MockKAnnotations.init(this, relaxed = true)
@@ -130,8 +136,15 @@ class EventEditTests : TearDown() {
 
   @Test
   fun testEventEditTagsDisplayed() {
+    nominatimLocationSearchViewModel =
+        NominatimLocationSearchViewModel(nominatimLocationRepositoryWithoutFunctionality)
     composeTestRule.setContent {
-      EventEditScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel)
+      EventEditScreen(
+          navigationAction,
+          searchViewModel,
+          associationViewModel,
+          eventViewModel,
+          nominatimLocationSearchViewModel)
     }
 
     composeTestRule.waitForIdle()
@@ -195,8 +208,15 @@ class EventEditTests : TearDown() {
 
   @Test
   fun testEventCannotBeSavedWhenEmptyField() {
+    nominatimLocationSearchViewModel =
+        NominatimLocationSearchViewModel(nominatimLocationRepositoryWithoutFunctionality)
     composeTestRule.setContent {
-      EventEditScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel)
+      EventEditScreen(
+          navigationAction,
+          searchViewModel,
+          associationViewModel,
+          eventViewModel,
+          nominatimLocationSearchViewModel)
     }
     composeTestRule
         .onNodeWithTag(EventEditTestTags.EVENT_TITLE, useUnmergedTree = true)
@@ -207,11 +227,18 @@ class EventEditTests : TearDown() {
 
   @Test
   fun testDeleteButtonWorksCorrectly() {
+    nominatimLocationSearchViewModel =
+        NominatimLocationSearchViewModel(nominatimLocationRepositoryWithoutFunctionality)
     var shouldBeTrue = false
     every { eventViewModel.deleteEvent(any(), any(), any()) } answers { shouldBeTrue = true }
 
     composeTestRule.setContent {
-      EventEditScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel)
+      EventEditScreen(
+          navigationAction,
+          searchViewModel,
+          associationViewModel,
+          eventViewModel,
+          nominatimLocationSearchViewModel)
     }
 
     composeTestRule.onNodeWithTag(EventEditTestTags.DELETE_BUTTON).performScrollTo().performClick()
@@ -221,6 +248,8 @@ class EventEditTests : TearDown() {
 
   @Test
   fun testSaveButtonSavesNewEvent() {
+    nominatimLocationSearchViewModel =
+        NominatimLocationSearchViewModel(nominatimLocationRepositoryWithoutFunctionality)
     var shouldBeTrue = false
 
     val eventSlot = slot<Event>()
@@ -230,7 +259,12 @@ class EventEditTests : TearDown() {
         }
 
     composeTestRule.setContent {
-      EventEditScreen(navigationAction, searchViewModel, associationViewModel, eventViewModel)
+      EventEditScreen(
+          navigationAction,
+          searchViewModel,
+          associationViewModel,
+          eventViewModel,
+          nominatimLocationSearchViewModel)
     }
     composeTestRule
         .onNodeWithTag(EventEditTestTags.EVENT_TITLE)

--- a/app/src/main/java/com/android/unio/MainActivity.kt
+++ b/app/src/main/java/com/android/unio/MainActivity.kt
@@ -165,7 +165,12 @@ fun UnioApp(imageRepository: ImageRepositoryFirebaseStorage) {
         }
       }
       composable(Screen.EDIT_EVENT) {
-        EventEditScreen(navigationActions, searchViewModel, associationViewModel, eventViewModel)
+        EventEditScreen(
+            navigationActions,
+            searchViewModel,
+            associationViewModel,
+            eventViewModel,
+            nominatimLocationSearchViewModel)
       }
     }
     navigation(startDestination = Screen.SAVED, route = Route.SAVED) {

--- a/app/src/main/java/com/android/unio/model/strings/test_tags/EventTestTags.kt
+++ b/app/src/main/java/com/android/unio/model/strings/test_tags/EventTestTags.kt
@@ -59,6 +59,7 @@ object EventEditTestTags {
   const val TAGGED_ASSOCIATIONS = "eventEditTaggedAssociations"
   const val DESCRIPTION = "eventEditDescription"
   const val LOCATION = "eventEditLocation"
+  const val LOCATION_SUGGESTION_ITEM = "eventCreationSuggestionItem: "
   const val SAVE_BUTTON = "eventEditSaveButton"
   const val DELETE_BUTTON = "eventEditDeleteButton"
   const val EVENT_IMAGE = "eventEditEventImage"

--- a/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
+++ b/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
@@ -60,6 +60,9 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+const val DROP_DOWN_MAX_CHARACTERS = 40
+const val DROP_DOWN_MAX_ROWS = 3
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun AssociationChips(

--- a/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
+++ b/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
@@ -78,6 +78,7 @@ const val DROP_DOWN_MAX_ROWS = 3
  *
  * @param locationSearchViewModel NominatimLocationSearchViewModel : ViewModel for searching
  *   locations.
+ * @param initialLocation Location? : Initial location to pre-fill the text field.
  * @param textFieldTestTag String : Test tag for the text field.
  * @param dropdownTestTag String : Test tag for the dropdown menu.
  * @param onLocationSelected (Location) -> Unit : Lambda that is called when a location is selected.
@@ -85,6 +86,7 @@ const val DROP_DOWN_MAX_ROWS = 3
 @Composable
 fun NominatimLocationPicker(
     locationSearchViewModel: NominatimLocationSearchViewModel,
+    initialLocation: Location?,
     textFieldTestTag: String,
     dropdownTestTag: String,
     onLocationSelected: (Location) -> Unit
@@ -95,11 +97,14 @@ fun NominatimLocationPicker(
   val locationSuggestions by locationSearchViewModel.locationSuggestions.collectAsState()
   var showDropdown by remember { mutableStateOf(false) }
 
+  var shouldDisplayInitialLocation by remember { mutableStateOf(true) }
+
   Box(modifier = Modifier.fillMaxWidth()) {
     OutlinedTextField(
-        value = locationQuery,
+        value = if (shouldDisplayInitialLocation) initialLocation?.name ?: "" else locationQuery,
         onValueChange = {
           locationSearchViewModel.setQuery(it)
+          shouldDisplayInitialLocation = false
           showDropdown = true
         },
         label = { Text(context.getString(R.string.event_creation_location_label)) },

--- a/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
+++ b/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
@@ -72,6 +72,16 @@ import java.util.Locale
 const val DROP_DOWN_MAX_CHARACTERS = 40
 const val DROP_DOWN_MAX_ROWS = 3
 
+/**
+ * Composable for the location picker that uses the Nominatim API to search for locations. It
+ * consists of a text field and a dropdown menu with location suggestions.
+ *
+ * @param locationSearchViewModel NominatimLocationSearchViewModel : ViewModel for searching
+ *   locations.
+ * @param textFieldTestTag String : Test tag for the text field.
+ * @param dropdownTestTag String : Test tag for the dropdown menu.
+ * @param onLocationSelected (Location) -> Unit : Lambda that is called when a location is selected.
+ */
 @Composable
 fun NominatimLocationPicker(
     locationSearchViewModel: NominatimLocationSearchViewModel,
@@ -132,6 +142,12 @@ fun NominatimLocationPicker(
   }
 }
 
+/**
+ * Composable for the association chips that show the selected associations.
+ *
+ * @param associations List<Pair<Association, MutableState<Boolean>>> : List of associations and
+ *   their selected state.
+ */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun AssociationChips(
@@ -156,6 +172,12 @@ fun AssociationChips(
   }
 }
 
+/**
+ * Composable for the banner image picker that allows the user to select an image from the gallery.
+ *
+ * @param eventBannerUri MutableState<Uri> : MutableState that holds the URI of the selected image.
+ * @param modifier Modifier : Modifier for the banner image picker.
+ */
 @Composable
 fun BannerImagePicker(eventBannerUri: MutableState<Uri>, modifier: Modifier) {
   val context = LocalContext.current
@@ -191,6 +213,20 @@ fun BannerImagePicker(eventBannerUri: MutableState<Uri>, modifier: Modifier) {
       }
 }
 
+/**
+ * Composable for the date and time picker that allows the user to select a date and time.
+ *
+ * @param dateString String : Label for the date field.
+ * @param timeString String : Label for the time field.
+ * @param modifier Modifier : Modifier for the date and time picker.
+ * @param initialDate Long? : Initial date in milliseconds. Used to pre-fill the date field.
+ * @param initialTime Long? : Initial time in milliseconds. Used to pre-fill the time field.
+ * @param dateFieldTestTag String : Test tag for the date field.
+ * @param timeFieldTestTag String : Test tag for the time field.
+ * @param datePickerTestTag String : Test tag for the date picker.
+ * @param timePickerTestTag String : Test tag for the time picker.
+ * @param onTimestamp (Timestamp) -> Unit : Lambda that is called when a timestamp is selected.
+ */
 @Composable
 fun DateAndTimePicker(
     dateString: String,
@@ -300,6 +336,13 @@ fun DateAndTimePicker(
   }
 }
 
+/**
+ * Composable for the date picker modal that allows the user to select a date.
+ *
+ * @param onDateSelected (Long?) -> Unit : Lambda that is called when a date is selected.
+ * @param onDismiss () -> Unit : Lambda that is called when the modal is dismissed.
+ * @param modifier Modifier : Modifier for the date picker modal.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DatePickerModal(
@@ -331,6 +374,13 @@ fun DatePickerModal(
       }
 }
 
+/**
+ * Composable for the time picker modal that allows the user to select a time.
+ *
+ * @param onTimeSelected (Long?) -> Unit : Lambda that is called when a time is selected.
+ * @param onDismiss () -> Unit : Lambda that is called when the modal is dismissed.
+ * @param modifier Modifier : Modifier for the time picker modal.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TimePickerModal(onTimeSelected: (Long?) -> Unit, onDismiss: () -> Unit, modifier: Modifier) {
@@ -351,6 +401,11 @@ fun TimePickerModal(onTimeSelected: (Long?) -> Unit, onDismiss: () -> Unit, modi
 /**
  * A Dialog that is the analog of the DatePickerDialog, but for TimePicker as it currently does not
  * exist in the Material3 library.
+ *
+ * @param onDismiss: () -> Unit: Lambda that is called when the dialog is dismissed.
+ * @param onConfirm: () -> Unit: Lambda that is called when the dialog is confirmed.
+ * @param modifier: Modifier: Modifier for the dialog.
+ * @param content: @Composable () -> Unit: Content of the dialog.
  */
 @Composable
 fun TimePickerDialog(
@@ -376,11 +431,23 @@ fun TimePickerDialog(
       text = { content() })
 }
 
+/**
+ * Converts milliseconds to a date string in the format "dd/MM/yy".
+ *
+ * @param millis: Long: Milliseconds to convert.
+ * @return String: Date string in the format "dd/MM/yy".
+ */
 fun convertMillisToDate(millis: Long): String {
   val formatter = SimpleDateFormat(DAY_MONTH_YEAR_FORMAT, Locale.getDefault())
   return formatter.format(Date(millis))
 }
 
+/**
+ * Converts milliseconds to a time string in the format "HH:mm".
+ *
+ * @param millis: Long: Milliseconds to convert.
+ * @return String: Time string in the format "HH:mm".
+ */
 fun convertMillisToTime(millis: Long): String {
   val formatter = SimpleDateFormat(HOUR_MINUTE_FORMAT, Locale.getDefault())
   return formatter.format(Date(millis))

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -3,12 +3,10 @@ package com.android.unio.ui.event
 import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -17,9 +15,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -39,7 +34,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.PopupProperties
 import com.android.unio.R
 import com.android.unio.model.association.Association
 import com.android.unio.model.association.AssociationViewModel
@@ -52,15 +46,12 @@ import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.strings.test_tags.EventCreationTestTags
 import com.android.unio.ui.components.AssociationChips
 import com.android.unio.ui.components.BannerImagePicker
-import com.android.unio.ui.components.DROP_DOWN_MAX_CHARACTERS
-import com.android.unio.ui.components.DROP_DOWN_MAX_ROWS
 import com.android.unio.ui.components.DateAndTimePicker
+import com.android.unio.ui.components.NominatimLocationPicker
 import com.android.unio.ui.event.overlay.AssociationsOverlay
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.theme.AppTypography
 import com.google.firebase.Timestamp
-
-
 
 @Composable
 fun EventCreationScreen(
@@ -89,9 +80,6 @@ fun EventCreationScreen(
   var endTimestamp: Timestamp? by remember { mutableStateOf(null) }
 
   var selectedLocation by remember { mutableStateOf<Location?>(null) }
-  val locationQuery by locationSearchViewModel.query.collectAsState()
-  val locationSuggestions by locationSearchViewModel.locationSuggestions.collectAsState()
-  var showDropdown by remember { mutableStateOf(false) }
 
   val eventBannerUri = remember { mutableStateOf<Uri>(Uri.EMPTY) }
 
@@ -201,59 +189,12 @@ fun EventCreationScreen(
             }
           }
 
-          Box(modifier = Modifier.fillMaxWidth()) {
-            OutlinedTextField(
-                value = locationQuery,
-                onValueChange = {
-                  locationSearchViewModel.setQuery(it)
-                  showDropdown = true
-                },
-                label = { Text(context.getString(R.string.event_creation_location_label)) },
-                placeholder = {
-                  Text(context.getString(R.string.event_creation_location_input_label))
-                },
-                modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.LOCATION))
-
-            DropdownMenu(
-                expanded = showDropdown && locationSuggestions.isNotEmpty(),
-                onDismissRequest = { showDropdown = false },
-                properties = PopupProperties(focusable = false),
-                modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp)) {
-                  locationSuggestions.take(DROP_DOWN_MAX_ROWS).forEach { location ->
-                    DropdownMenuItem(
-                        text = {
-                          Text(
-                              text =
-                                  location.name.take(DROP_DOWN_MAX_CHARACTERS) +
-                                      if (location.name.length > DROP_DOWN_MAX_CHARACTERS)
-                                          context.getString(
-                                              R.string.event_creation_location_dropdown_points)
-                                      else "",
-                              maxLines = 1)
-                        },
-                        onClick = {
-                          locationSearchViewModel.setQuery(location.name)
-                          selectedLocation = location
-                          showDropdown = false
-                        },
-                        modifier =
-                            Modifier.padding(8.dp)
-                                .testTag(
-                                    EventCreationTestTags.LOCATION_SUGGESTION_ITEM +
-                                        location.latitude))
-                      HorizontalDivider()
-                  }
-
-                  if (locationSuggestions.size > DROP_DOWN_MAX_ROWS) {
-                    DropdownMenuItem(
-                        text = {
-                          Text(context.getString(R.string.event_creation_location_dropdown_more))
-                        },
-                        onClick = {},
-                        modifier = Modifier.padding(8.dp))
-                  }
-                }
-          }
+          NominatimLocationPicker(
+              locationSearchViewModel,
+              EventCreationTestTags.LOCATION,
+              EventCreationTestTags.LOCATION_SUGGESTION_ITEM) {
+                selectedLocation = it
+              }
 
           Spacer(modifier = Modifier.width(10.dp))
 

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -191,6 +191,7 @@ fun EventCreationScreen(
 
           NominatimLocationPicker(
               locationSearchViewModel,
+              null,
               EventCreationTestTags.LOCATION,
               EventCreationTestTags.LOCATION_SUGGESTION_ITEM) {
                 selectedLocation = it

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -17,9 +17,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Button
-import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -52,14 +52,15 @@ import com.android.unio.model.search.SearchViewModel
 import com.android.unio.model.strings.test_tags.EventCreationTestTags
 import com.android.unio.ui.components.AssociationChips
 import com.android.unio.ui.components.BannerImagePicker
+import com.android.unio.ui.components.DROP_DOWN_MAX_CHARACTERS
+import com.android.unio.ui.components.DROP_DOWN_MAX_ROWS
 import com.android.unio.ui.components.DateAndTimePicker
 import com.android.unio.ui.event.overlay.AssociationsOverlay
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.theme.AppTypography
 import com.google.firebase.Timestamp
 
-private const val DROP_DOWN_MAX_CHARACTERS = 40
-private const val DROP_DOWN_MAX_ROWS = 3
+
 
 @Composable
 fun EventCreationScreen(
@@ -240,7 +241,7 @@ fun EventCreationScreen(
                                 .testTag(
                                     EventCreationTestTags.LOCATION_SUGGESTION_ITEM +
                                         location.latitude))
-                    Divider()
+                      HorizontalDivider()
                   }
 
                   if (locationSuggestions.size > DROP_DOWN_MAX_ROWS) {

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -109,7 +109,8 @@ fun EventEditScreen(
   val initialEndTime = getHHMMInMillisFromTimestamp(eventToEdit.endDate)
   val initialEndDate = eventToEdit.endDate.toDate().time - initialEndTime
 
-  var selectedLocation by remember { mutableStateOf<Location?>(null) }
+  val initialLocation: Location? = eventToEdit.location
+  var selectedLocation by remember { mutableStateOf<Location?>(eventToEdit.location) }
 
   val eventBannerUri = remember { mutableStateOf<Uri>(eventToEdit.image.toUri()) }
 
@@ -221,6 +222,7 @@ fun EventEditScreen(
 
           NominatimLocationPicker(
               locationSearchViewModel,
+              initialLocation,
               EventEditTestTags.LOCATION,
               EventEditTestTags.LOCATION_SUGGESTION_ITEM) {
                 selectedLocation = it


### PR DESCRIPTION
As my previous PR adding the event edit feature was developed concurrently with @Zafouche 's PR that added the nominatim location picker in the EventCreation composable, the location picker wasn't added to the Edit screen. This PR aims to fix this. It extracts the location picker in the EventEditComponents file and changes EventCreation.kt accordingly, and adds it to EventEdit. I also added some documentation to EventEditComponents as it was lacking. 

This is currently a draft PR as further tests are needed in EventEdit.
