### PR TITLE
Feat/manage pictures

### DIFF
--- a/app/src/androidTest/java/com/android/unio/components/authentication/PictureSelectionToolTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/authentication/PictureSelectionToolTest.kt
@@ -1,0 +1,86 @@
+package com.android.unio.components.authentication
+
+import android.net.Uri
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.filters.LargeTest
+import com.android.unio.TearDown
+import com.android.unio.model.strings.test_tags.PictureSelectionToolTestTags
+import com.android.unio.ui.components.PictureSelectionTool
+import com.google.firebase.Firebase
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.auth
+import com.google.firebase.auth.internal.zzac
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+@LargeTest
+@HiltAndroidTest
+class PictureSelectionToolTest : TearDown() {
+
+  @MockK private lateinit var firebaseAuth: FirebaseAuth
+  @MockK private lateinit var mockFirebaseUser: zzac
+
+  @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val hiltRule = HiltAndroidRule(this)
+
+  private val mockOnValidate: (List<Uri>) -> Unit = mock()
+  private val mockOnCancel: () -> Unit = mock()
+
+  @Before
+  fun setUp() {
+    MockKAnnotations.init(this, relaxed = true)
+
+    // Mocking Firebase.auth and its behavior
+    mockkStatic(FirebaseAuth::class)
+    every { Firebase.auth } returns firebaseAuth
+    every { firebaseAuth.currentUser } returns mockFirebaseUser
+    every { mockFirebaseUser.uid } returns "mocked-uid"
+  }
+
+  @Test
+  fun testInitialUIState() {
+    composeTestRule.setContent {
+      PictureSelectionTool(
+          maxPictures = 3,
+          allowGallery = true,
+          allowCamera = true,
+          onValidate = mockOnValidate,
+          onCancel = mockOnCancel,
+          initialSelectedPictures = emptyList())
+    }
+    // Verify that initial UI elements are displayed
+    composeTestRule.onNodeWithTag(PictureSelectionToolTestTags.GALLERY_ADD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(PictureSelectionToolTestTags.CAMERA_ADD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(PictureSelectionToolTestTags.CANCEL_BUTTON).assertIsDisplayed()
+  }
+
+  @Test
+  fun testHavingPictures() {
+    val mockUri1 = mockk<Uri>(relaxed = true)
+
+    composeTestRule.setContent {
+      PictureSelectionTool(
+          maxPictures = 3,
+          allowGallery = true,
+          allowCamera = true,
+          onValidate = mockOnValidate,
+          onCancel = mockOnCancel,
+          initialSelectedPictures = listOf(mockUri1))
+    }
+    // Verify that the selected pictures are displayed
+    composeTestRule.onNodeWithTag(PictureSelectionToolTestTags.SELECTED_PICTURE).assertIsDisplayed()
+    // Ensure that the Validate button is now visible
+    composeTestRule.onNodeWithTag(PictureSelectionToolTestTags.VALIDATE_BUTTON).assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/android/unio/components/authentication/PictureSelectionToolTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/authentication/PictureSelectionToolTest.kt
@@ -22,7 +22,6 @@ import io.mockk.mockkStatic
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.mock
 
 @LargeTest
 @HiltAndroidTest
@@ -34,8 +33,8 @@ class PictureSelectionToolTest : TearDown() {
   @get:Rule val composeTestRule = createComposeRule()
   @get:Rule val hiltRule = HiltAndroidRule(this)
 
-  private val mockOnValidate: (List<Uri>) -> Unit = mock()
-  private val mockOnCancel: () -> Unit = mock()
+  private val mockOnValidate: (List<Uri>) -> Unit = mockk()
+  private val mockOnCancel: () -> Unit = mockk()
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/com/android/unio/components/authentication/PictureSelectionToolTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/authentication/PictureSelectionToolTest.kt
@@ -33,9 +33,6 @@ class PictureSelectionToolTest : TearDown() {
   @get:Rule val composeTestRule = createComposeRule()
   @get:Rule val hiltRule = HiltAndroidRule(this)
 
-  private val mockOnValidate: (List<Uri>) -> Unit = mockk()
-  private val mockOnCancel: () -> Unit = mockk()
-
   @Before
   fun setUp() {
     MockKAnnotations.init(this, relaxed = true)
@@ -54,8 +51,8 @@ class PictureSelectionToolTest : TearDown() {
           maxPictures = 3,
           allowGallery = true,
           allowCamera = true,
-          onValidate = mockOnValidate,
-          onCancel = mockOnCancel,
+          onValidate = {},
+          onCancel = {},
           initialSelectedPictures = emptyList())
     }
     // Verify that initial UI elements are displayed
@@ -73,8 +70,8 @@ class PictureSelectionToolTest : TearDown() {
           maxPictures = 3,
           allowGallery = true,
           allowCamera = true,
-          onValidate = mockOnValidate,
-          onCancel = mockOnCancel,
+          onValidate = {},
+          onCancel = {},
           initialSelectedPictures = listOf(mockUri1))
     }
     // Verify that the selected pictures are displayed

--- a/app/src/androidTest/java/com/android/unio/end2end/UserAccountCreationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/end2end/UserAccountCreationTest.kt
@@ -88,8 +88,6 @@ class UserAccountCreationTest : EndToEndTest() {
     composeTestRule.onNodeWithTag(AccountDetailsTestTags.PROFILE_PICTURE_ICON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(AccountDetailsTestTags.PROFILE_PICTURE_ICON).performClick()
 
-    // balablablaGoBack !dsajdsajdbsakjdsa
-
     composeTestRule
         .onNodeWithTag(AccountDetailsTestTags.CONTINUE_BUTTON)
         .assertDisplayComponentInScroll()

--- a/app/src/androidTest/java/com/android/unio/end2end/UserAccountCreationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/end2end/UserAccountCreationTest.kt
@@ -85,6 +85,11 @@ class UserAccountCreationTest : EndToEndTest() {
     composeTestRule.onNodeWithTag(InterestsOverlayTestTags.SAVE_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(InterestsOverlayTestTags.SAVE_BUTTON).performClick()
 
+    composeTestRule.onNodeWithTag(AccountDetailsTestTags.PROFILE_PICTURE_ICON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(AccountDetailsTestTags.PROFILE_PICTURE_ICON).performClick()
+
+    // balablablaGoBack !dsajdsajdbsakjdsa
+
     composeTestRule
         .onNodeWithTag(AccountDetailsTestTags.CONTINUE_BUTTON)
         .assertDisplayComponentInScroll()

--- a/app/src/main/java/com/android/unio/model/strings/test_tags/AuthenticationTestTags.kt
+++ b/app/src/main/java/com/android/unio/model/strings/test_tags/AuthenticationTestTags.kt
@@ -94,3 +94,12 @@ object WelcomeTestTags {
   const val BUTTON = "welcomeButton"
   const val FORGOT_PASSWORD = "welcomeForgotPassword"
 }
+
+object PictureSelectionToolTestTags {
+  const val SELECTED_PICTURE = "pictureSelectionToolSelectedPicture"
+  const val REMOVE_PICTURE = "pictureSelectionToolRemovePicture"
+  const val GALLERY_ADD = "pictureSelectionToolGalleryAdd"
+  const val CAMERA_ADD = "pictureSelectionToolCameraAdd"
+  const val VALIDATE_BUTTON = "pictureSelectionToolValidateButton"
+  const val CANCEL_BUTTON = "pictureSelectionToolCancelButton"
+}

--- a/app/src/main/java/com/android/unio/model/strings/test_tags/AuthenticationTestTags.kt
+++ b/app/src/main/java/com/android/unio/model/strings/test_tags/AuthenticationTestTags.kt
@@ -102,4 +102,6 @@ object PictureSelectionToolTestTags {
   const val CAMERA_ADD = "pictureSelectionToolCameraAdd"
   const val VALIDATE_BUTTON = "pictureSelectionToolValidateButton"
   const val CANCEL_BUTTON = "pictureSelectionToolCancelButton"
+  const val NEW_PROFILE_PICTURE = "new_profile_picture.jpg"
+  const val IMAGE_JPEG = "image/jpeg"
 }

--- a/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
+++ b/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
@@ -1,0 +1,167 @@
+package com.android.unio.ui.components
+
+import android.content.ContentValues
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+
+
+/**
+ * A composable function to select and display pictures from the gallery or camera.
+ * It allows the user to add pictures, see selected pictures in a grid, and validate the selection.
+ *
+ * @param maxPictures The maximum number of pictures that can be selected.
+ * @param allowGallery Boolean to specify if selecting from the gallery is allowed.
+ * @param allowCamera Boolean to specify if taking pictures with the camera is allowed.
+ * @param onValidate Lambda to handle the selected pictures after validation.
+ * @param onCancel Lambda to handle the cancellation of the selection.
+ */
+@Composable
+fun PictureSelectionTool(
+    maxPictures: Int,
+    allowGallery: Boolean,
+    allowCamera: Boolean,
+    onValidate: (List<Uri>) -> Unit,
+    onCancel: () -> Unit
+) {
+    val context = LocalContext.current
+
+    val selectedPictures = remember { mutableStateListOf<Uri>() }
+
+    // Launcher for selecting multiple images from the gallery
+    val pickMediaLauncher = rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia()) { uris ->
+        if (uris != null) {
+            selectedPictures.addAll(uris.take(maxPictures - selectedPictures.size))
+        }
+    }
+
+    val cameraImageUri = remember { mutableStateOf<Uri?>(null) }
+    // Launcher for taking a picture with the camera
+    val takePictureLauncher = rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { success ->
+        if (success && cameraImageUri.value != null) {
+            selectedPictures.add(cameraImageUri.value!!)
+        }
+    }
+
+    /**
+     * Creates a temporary URI for storing an image taken by the camera.
+     *
+     * @return A URI pointing to the location where the new image will be stored.
+     */
+    fun createImageUri(): Uri {
+        val resolver = context.contentResolver
+        val contentValues = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, "new_profile_picture.jpg")
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+        }
+        return resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)!!
+    }
+
+    // User interface for the picture selection tool
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(16.dp)
+    ) {
+        Text("Selected Pictures: ${selectedPictures.size}/$maxPictures")
+
+        // Display selected pictures in a scrollable grid with a fixed number of columns
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(3),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            contentPadding = PaddingValues(4.dp)
+        ) {
+            items(selectedPictures.size) { index ->
+                val uri = selectedPictures[index]
+                Box(
+                    modifier = Modifier
+                        .size(100.dp)
+                        .clip(CircleShape)
+                        .padding(4.dp)
+                ) {
+                    // Display the selected image
+                    Image(
+                        painter = rememberAsyncImagePainter(uri),
+                        contentDescription = "Selected Picture",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                    Icon(
+                        Icons.Default.Close,
+                        contentDescription = "Remove Picture",
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .clickable { selectedPictures.remove(uri) }
+                            .padding(4.dp)
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Buttons to add pictures from the gallery or camera
+        Row(horizontalArrangement = Arrangement.SpaceEvenly, modifier = Modifier.fillMaxWidth()) {
+            // Add picture from the gallery if allowed and the max limit isn't reached
+            if (allowGallery && selectedPictures.size < maxPictures) {
+                OutlinedButton(onClick = {
+                    pickMediaLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                }) {
+                    Icon(Icons.Default.Add, contentDescription = "Add from Gallery")
+                    Text("Gallery")
+                }
+            }
+
+            // Take a picture with the camera if allowed and the max limit isn't reached
+            if (allowCamera && selectedPictures.size < maxPictures) {
+                OutlinedButton(onClick = {
+                    val uri = createImageUri() // Local stable reference
+                    cameraImageUri.value = uri
+                    takePictureLauncher.launch(uri)
+                }) {
+                    Icon(Icons.Default.Add, contentDescription = "Take Picture")
+                    Text("Camera")
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Buttons for validating or canceling the picture selection
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            Button(onClick = { onValidate(selectedPictures) }) {
+                Icon(Icons.Default.Check, contentDescription = "Validate")
+                Text("Validate")
+            }
+
+            OutlinedButton(onClick = onCancel) {
+                Text("Cancel")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
+++ b/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
@@ -9,9 +9,9 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
@@ -26,10 +26,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 
-
 /**
- * A composable function to select and display pictures from the gallery or camera.
- * It allows the user to add pictures, see selected pictures in a grid, and validate the selection.
+ * A composable function to select and display pictures from the gallery or camera. It allows the
+ * user to add pictures, see selected pictures in a grid, and validate the selection.
  *
  * @param maxPictures The maximum number of pictures that can be selected.
  * @param allowGallery Boolean to specify if selecting from the gallery is allowed.
@@ -45,123 +44,111 @@ fun PictureSelectionTool(
     onValidate: (List<Uri>) -> Unit,
     onCancel: () -> Unit
 ) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    val selectedPictures = remember { mutableStateListOf<Uri>() }
+  val selectedPictures = remember { mutableStateListOf<Uri>() }
 
-    // Launcher for selecting multiple images from the gallery
-    val pickMediaLauncher = rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia()) { uris ->
+  // Launcher for selecting multiple images from the gallery
+  val pickMediaLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia()) { uris ->
         if (uris != null) {
-            selectedPictures.addAll(uris.take(maxPictures - selectedPictures.size))
+          selectedPictures.addAll(uris.take(maxPictures - selectedPictures.size))
         }
-    }
+      }
 
-    val cameraImageUri = remember { mutableStateOf<Uri?>(null) }
-    // Launcher for taking a picture with the camera
-    val takePictureLauncher = rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { success ->
+  val cameraImageUri = remember { mutableStateOf<Uri?>(null) }
+  // Launcher for taking a picture with the camera
+  val takePictureLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { success ->
         if (success && cameraImageUri.value != null) {
-            selectedPictures.add(cameraImageUri.value!!)
+          selectedPictures.add(cameraImageUri.value!!)
         }
+      }
+
+  /**
+   * Creates a temporary URI for storing an image taken by the camera.
+   *
+   * @return A URI pointing to the location where the new image will be stored.
+   */
+  fun createImageUri(): Uri {
+    val resolver = context.contentResolver
+    val contentValues =
+        ContentValues().apply {
+          put(MediaStore.Images.Media.DISPLAY_NAME, "new_profile_picture.jpg")
+          put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+        }
+    return resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)!!
+  }
+
+  // User interface for the picture selection tool
+  Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(16.dp)) {
+    Text("Selected Pictures: ${selectedPictures.size}/$maxPictures")
+
+    // Display selected pictures in a scrollable grid with a fixed number of columns
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        contentPadding = PaddingValues(4.dp)) {
+          items(selectedPictures.size) { index ->
+            val uri = selectedPictures[index]
+            Box(modifier = Modifier.size(100.dp).clip(CircleShape).padding(4.dp)) {
+              // Display the selected image
+              Image(
+                  painter = rememberAsyncImagePainter(uri),
+                  contentDescription = "Selected Picture",
+                  contentScale = ContentScale.Crop,
+                  modifier = Modifier.fillMaxSize())
+              Icon(
+                  Icons.Default.Close,
+                  contentDescription = "Remove Picture",
+                  modifier =
+                      Modifier.align(Alignment.TopEnd)
+                          .clickable { selectedPictures.remove(uri) }
+                          .padding(4.dp))
+            }
+          }
+        }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // Buttons to add pictures from the gallery or camera
+    Row(horizontalArrangement = Arrangement.SpaceEvenly, modifier = Modifier.fillMaxWidth()) {
+      // Add picture from the gallery if allowed and the max limit isn't reached
+      if (allowGallery && selectedPictures.size < maxPictures) {
+        OutlinedButton(
+            onClick = {
+              pickMediaLauncher.launch(
+                  PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            }) {
+              Icon(Icons.Default.Add, contentDescription = "Add from Gallery")
+              Text("Gallery")
+            }
+      }
+
+      // Take a picture with the camera if allowed and the max limit isn't reached
+      if (allowCamera && selectedPictures.size < maxPictures) {
+        OutlinedButton(
+            onClick = {
+              val uri = createImageUri() // Local stable reference
+              cameraImageUri.value = uri
+              takePictureLauncher.launch(uri)
+            }) {
+              Icon(Icons.Default.Add, contentDescription = "Take Picture")
+              Text("Camera")
+            }
+      }
     }
 
-    /**
-     * Creates a temporary URI for storing an image taken by the camera.
-     *
-     * @return A URI pointing to the location where the new image will be stored.
-     */
-    fun createImageUri(): Uri {
-        val resolver = context.contentResolver
-        val contentValues = ContentValues().apply {
-            put(MediaStore.Images.Media.DISPLAY_NAME, "new_profile_picture.jpg")
-            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
-        }
-        return resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)!!
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // Buttons for validating or canceling the picture selection
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+      Button(onClick = { onValidate(selectedPictures) }) {
+        Icon(Icons.Default.Check, contentDescription = "Validate")
+        Text("Validate")
+      }
+
+      OutlinedButton(onClick = onCancel) { Text("Cancel") }
     }
-
-    // User interface for the picture selection tool
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.padding(16.dp)
-    ) {
-        Text("Selected Pictures: ${selectedPictures.size}/$maxPictures")
-
-        // Display selected pictures in a scrollable grid with a fixed number of columns
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(3),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp),
-            contentPadding = PaddingValues(4.dp)
-        ) {
-            items(selectedPictures.size) { index ->
-                val uri = selectedPictures[index]
-                Box(
-                    modifier = Modifier
-                        .size(100.dp)
-                        .clip(CircleShape)
-                        .padding(4.dp)
-                ) {
-                    // Display the selected image
-                    Image(
-                        painter = rememberAsyncImagePainter(uri),
-                        contentDescription = "Selected Picture",
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxSize()
-                    )
-                    Icon(
-                        Icons.Default.Close,
-                        contentDescription = "Remove Picture",
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .clickable { selectedPictures.remove(uri) }
-                            .padding(4.dp)
-                    )
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Buttons to add pictures from the gallery or camera
-        Row(horizontalArrangement = Arrangement.SpaceEvenly, modifier = Modifier.fillMaxWidth()) {
-            // Add picture from the gallery if allowed and the max limit isn't reached
-            if (allowGallery && selectedPictures.size < maxPictures) {
-                OutlinedButton(onClick = {
-                    pickMediaLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
-                }) {
-                    Icon(Icons.Default.Add, contentDescription = "Add from Gallery")
-                    Text("Gallery")
-                }
-            }
-
-            // Take a picture with the camera if allowed and the max limit isn't reached
-            if (allowCamera && selectedPictures.size < maxPictures) {
-                OutlinedButton(onClick = {
-                    val uri = createImageUri() // Local stable reference
-                    cameraImageUri.value = uri
-                    takePictureLauncher.launch(uri)
-                }) {
-                    Icon(Icons.Default.Add, contentDescription = "Take Picture")
-                    Text("Camera")
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Buttons for validating or canceling the picture selection
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        ) {
-            Button(onClick = { onValidate(selectedPictures) }) {
-                Icon(Icons.Default.Check, contentDescription = "Validate")
-                Text("Validate")
-            }
-
-            OutlinedButton(onClick = onCancel) {
-                Text("Cancel")
-            }
-        }
-    }
+  }
 }

--- a/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
+++ b/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
+import com.android.unio.R
 import com.android.unio.model.strings.test_tags.PictureSelectionToolTestTags
 
 /**
@@ -91,7 +92,9 @@ fun PictureSelectionTool(
 
   // User interface for the picture selection tool
   Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(16.dp)) {
-    Text("Selected Pictures: ${selectedPictures.size}/$maxPictures")
+    Text(
+        context.getString(R.string.selection_tool_selected_picture_text) +
+            ": ${selectedPictures.size}/$maxPictures")
 
     // Display selected pictures in a scrollable grid with a fixed number of columns
     LazyVerticalGrid(
@@ -104,13 +107,14 @@ fun PictureSelectionTool(
               // Display the selected image
               Image(
                   painter = rememberAsyncImagePainter(uri),
-                  contentDescription = "Selected Picture",
+                  contentDescription =
+                      context.getString(R.string.selection_tool_selected_picture_text),
                   contentScale = ContentScale.Crop,
                   modifier =
                       Modifier.fillMaxSize().testTag(PictureSelectionToolTestTags.SELECTED_PICTURE))
               Icon(
                   Icons.Default.Close,
-                  contentDescription = "Remove Picture",
+                  contentDescription = context.getString(R.string.selection_tool_remove_picture),
                   modifier =
                       Modifier.align(Alignment.TopEnd)
                           .clickable { selectedPictures.remove(uri) }
@@ -132,8 +136,11 @@ fun PictureSelectionTool(
                   PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
             },
             modifier = Modifier.testTag(PictureSelectionToolTestTags.GALLERY_ADD)) {
-              Icon(Icons.Default.Add, contentDescription = "Add from Gallery")
-              Text("Gallery")
+              Icon(
+                  Icons.Default.Add,
+                  contentDescription =
+                      context.getString(R.string.selection_tool_add_gallery_content_description))
+              Text(context.getString(R.string.selection_tool_gallery_text))
             }
       }
 
@@ -146,8 +153,10 @@ fun PictureSelectionTool(
               takePictureLauncher.launch(uri)
             },
             modifier = Modifier.testTag(PictureSelectionToolTestTags.CAMERA_ADD)) {
-              Icon(Icons.Default.Add, contentDescription = "Take Picture")
-              Text("Camera")
+              Icon(
+                  Icons.Default.Add,
+                  contentDescription = context.getString(R.string.selection_tool_take_picture))
+              Text(context.getString(R.string.selection_tool_camera_text))
             }
       }
     }
@@ -159,14 +168,16 @@ fun PictureSelectionTool(
       Button(
           onClick = { onValidate(selectedPictures) },
           modifier = Modifier.testTag(PictureSelectionToolTestTags.VALIDATE_BUTTON)) {
-            Icon(Icons.Default.Check, contentDescription = "Validate")
-            Text("Validate")
+            Icon(
+                Icons.Default.Check,
+                contentDescription = context.getString(R.string.selection_tool_validate_text))
+            Text(context.getString(R.string.selection_tool_validate_text))
           }
 
       OutlinedButton(
           onClick = onCancel,
           modifier = Modifier.testTag(PictureSelectionToolTestTags.CANCEL_BUTTON)) {
-            Text("Cancel")
+            Text(context.getString(R.string.selection_tool_cancel_text))
           }
     }
   }

--- a/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
+++ b/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
@@ -84,8 +84,10 @@ fun PictureSelectionTool(
     val resolver = context.contentResolver
     val contentValues =
         ContentValues().apply {
-          put(MediaStore.Images.Media.DISPLAY_NAME, "new_profile_picture.jpg")
-          put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+          put(
+              MediaStore.Images.Media.DISPLAY_NAME,
+              PictureSelectionToolTestTags.NEW_PROFILE_PICTURE)
+          put(MediaStore.Images.Media.MIME_TYPE, PictureSelectionToolTestTags.IMAGE_JPEG)
         }
     return resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)!!
   }

--- a/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
+++ b/app/src/main/java/com/android/unio/ui/components/PictureSelectionTool.kt
@@ -23,8 +23,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
+import com.android.unio.model.strings.test_tags.PictureSelectionToolTestTags
 
 /**
  * A composable function to select and display pictures from the gallery or camera. It allows the
@@ -42,11 +44,18 @@ fun PictureSelectionTool(
     allowGallery: Boolean,
     allowCamera: Boolean,
     onValidate: (List<Uri>) -> Unit,
-    onCancel: () -> Unit
+    onCancel: () -> Unit,
+    initialSelectedPictures: List<Uri>
 ) {
   val context = LocalContext.current
 
   val selectedPictures = remember { mutableStateListOf<Uri>() }
+
+  // Initialize selectedPictures with initialSelectedPictures
+  LaunchedEffect(initialSelectedPictures) {
+    selectedPictures.clear() // Clear existing pictures, if any
+    selectedPictures.addAll(initialSelectedPictures) // Add the initial selected pictures
+  }
 
   // Launcher for selecting multiple images from the gallery
   val pickMediaLauncher =
@@ -97,14 +106,16 @@ fun PictureSelectionTool(
                   painter = rememberAsyncImagePainter(uri),
                   contentDescription = "Selected Picture",
                   contentScale = ContentScale.Crop,
-                  modifier = Modifier.fillMaxSize())
+                  modifier =
+                      Modifier.fillMaxSize().testTag(PictureSelectionToolTestTags.SELECTED_PICTURE))
               Icon(
                   Icons.Default.Close,
                   contentDescription = "Remove Picture",
                   modifier =
                       Modifier.align(Alignment.TopEnd)
                           .clickable { selectedPictures.remove(uri) }
-                          .padding(4.dp))
+                          .padding(4.dp)
+                          .testTag(PictureSelectionToolTestTags.REMOVE_PICTURE))
             }
           }
         }
@@ -119,7 +130,8 @@ fun PictureSelectionTool(
             onClick = {
               pickMediaLauncher.launch(
                   PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
-            }) {
+            },
+            modifier = Modifier.testTag(PictureSelectionToolTestTags.GALLERY_ADD)) {
               Icon(Icons.Default.Add, contentDescription = "Add from Gallery")
               Text("Gallery")
             }
@@ -132,7 +144,8 @@ fun PictureSelectionTool(
               val uri = createImageUri() // Local stable reference
               cameraImageUri.value = uri
               takePictureLauncher.launch(uri)
-            }) {
+            },
+            modifier = Modifier.testTag(PictureSelectionToolTestTags.CAMERA_ADD)) {
               Icon(Icons.Default.Add, contentDescription = "Take Picture")
               Text("Camera")
             }
@@ -143,12 +156,18 @@ fun PictureSelectionTool(
 
     // Buttons for validating or canceling the picture selection
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
-      Button(onClick = { onValidate(selectedPictures) }) {
-        Icon(Icons.Default.Check, contentDescription = "Validate")
-        Text("Validate")
-      }
+      Button(
+          onClick = { onValidate(selectedPictures) },
+          modifier = Modifier.testTag(PictureSelectionToolTestTags.VALIDATE_BUTTON)) {
+            Icon(Icons.Default.Check, contentDescription = "Validate")
+            Text("Validate")
+          }
 
-      OutlinedButton(onClick = onCancel) { Text("Cancel") }
+      OutlinedButton(
+          onClick = onCancel,
+          modifier = Modifier.testTag(PictureSelectionToolTestTags.CANCEL_BUTTON)) {
+            Text("Cancel")
+          }
     }
   }
 }

--- a/app/src/main/java/com/android/unio/ui/components/UserEditionComponents.kt
+++ b/app/src/main/java/com/android/unio/ui/components/UserEditionComponents.kt
@@ -1,6 +1,8 @@
 package com.android.unio.ui.components
 
+import android.content.ContentValues
 import android.net.Uri
+import android.provider.MediaStore
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -11,6 +13,9 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.ModalBottomSheetLayout
+
+import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.rounded.AccountCircle
@@ -19,6 +24,10 @@ import androidx.compose.material3.InputChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,6 +42,12 @@ import com.android.unio.model.user.Interest
 import com.android.unio.model.user.UserSocial
 import com.android.unio.ui.image.AsyncImageWrapper
 import com.android.unio.ui.theme.primaryLight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
 
 @Composable
 private fun ProfilePictureWithRemoveIcon(
@@ -58,37 +73,66 @@ private fun ProfilePictureWithRemoveIcon(
   }
 }
 
+
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfilePicturePicker(
     profilePictureUri: MutableState<Uri>,
     onProfilePictureUriChange: () -> Unit,
     testTag: String
 ) {
-  val context = LocalContext.current
-  val pickMedia =
-      rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
-        if (uri != null) {
-          profilePictureUri.value = uri
-        }
-      }
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded  = true)
+    val scope = rememberCoroutineScope()
+    var showSheet by remember { mutableStateOf(false) }
 
-  if (profilePictureUri.value == Uri.EMPTY) {
-    Icon(
-        imageVector = Icons.Rounded.AccountCircle,
-        contentDescription = context.getString(R.string.account_details_content_description_add),
-        tint = primaryLight,
-        modifier =
-            Modifier.clickable {
-                  pickMedia.launch(
-                      PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+    if (profilePictureUri.value == Uri.EMPTY) {
+        Icon(
+            imageVector = Icons.Rounded.AccountCircle,
+            contentDescription = context.getString(R.string.account_details_content_description_add),
+            tint = primaryLight,
+            modifier = Modifier
+                .clickable {
+                    showSheet = true
                 }
                 .size(100.dp)
-                .testTag(testTag))
-  } else {
-    ProfilePictureWithRemoveIcon(
-        profilePictureUri = profilePictureUri.value, onRemove = onProfilePictureUriChange)
-  }
+                .testTag(testTag)
+        )
+    } else {
+        ProfilePictureWithRemoveIcon(
+            profilePictureUri = profilePictureUri.value,
+            onRemove = onProfilePictureUriChange
+        )
+    }
+
+    if (showSheet) {
+        ModalBottomSheet(
+            sheetState = sheetState,
+            onDismissRequest = { scope.launch { sheetState.hide(); showSheet=false } },
+            content = {
+                PictureSelectionTool(
+                    maxPictures = 1,
+                    allowGallery = true,
+                    allowCamera = true,
+                    onValidate = { uris ->
+                        if (uris.isNotEmpty()) {
+                            profilePictureUri.value = uris.first() // Use the first selected as the profile picture
+                        }
+                        scope.launch { sheetState.hide() }
+                        showSheet = false
+                    },
+                    onCancel = {
+                        scope.launch { sheetState.hide() }
+                        showSheet = false
+                    }
+                )
+            }
+        )
+    }
 }
+
+
 
 @Composable
 fun InterestInputChip(pair: Pair<Interest, MutableState<Boolean>>, testTag: String) {

--- a/app/src/main/java/com/android/unio/ui/components/UserEditionComponents.kt
+++ b/app/src/main/java/com/android/unio/ui/components/UserEditionComponents.kt
@@ -1,11 +1,6 @@
 package com.android.unio.ui.components
 
-import android.content.ContentValues
 import android.net.Uri
-import android.provider.MediaStore
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -13,20 +8,21 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.ModalBottomSheetLayout
-
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.rounded.AccountCircle
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.InputChip
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,11 +38,6 @@ import com.android.unio.model.user.Interest
 import com.android.unio.model.user.UserSocial
 import com.android.unio.ui.image.AsyncImageWrapper
 import com.android.unio.ui.theme.primaryLight
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetState
-import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
 
 @Composable
@@ -73,8 +64,6 @@ private fun ProfilePictureWithRemoveIcon(
   }
 }
 
-
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfilePicturePicker(
@@ -82,57 +71,51 @@ fun ProfilePicturePicker(
     onProfilePictureUriChange: () -> Unit,
     testTag: String
 ) {
-    val context = LocalContext.current
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded  = true)
-    val scope = rememberCoroutineScope()
-    var showSheet by remember { mutableStateOf(false) }
+  val context = LocalContext.current
+  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+  val scope = rememberCoroutineScope()
+  var showSheet by remember { mutableStateOf(false) }
 
-    if (profilePictureUri.value == Uri.EMPTY) {
-        Icon(
-            imageVector = Icons.Rounded.AccountCircle,
-            contentDescription = context.getString(R.string.account_details_content_description_add),
-            tint = primaryLight,
-            modifier = Modifier
-                .clickable {
-                    showSheet = true
+  if (profilePictureUri.value == Uri.EMPTY) {
+    Icon(
+        imageVector = Icons.Rounded.AccountCircle,
+        contentDescription = context.getString(R.string.account_details_content_description_add),
+        tint = primaryLight,
+        modifier = Modifier.clickable { showSheet = true }.size(100.dp).testTag(testTag))
+  } else {
+    ProfilePictureWithRemoveIcon(
+        profilePictureUri = profilePictureUri.value, onRemove = onProfilePictureUriChange)
+  }
+
+  if (showSheet) {
+    ModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = {
+          scope.launch {
+            sheetState.hide()
+            showSheet = false
+          }
+        },
+        content = {
+          PictureSelectionTool(
+              maxPictures = 1,
+              allowGallery = true,
+              allowCamera = true,
+              onValidate = { uris ->
+                if (uris.isNotEmpty()) {
+                  profilePictureUri.value =
+                      uris.first() // Use the first selected as the profile picture
                 }
-                .size(100.dp)
-                .testTag(testTag)
-        )
-    } else {
-        ProfilePictureWithRemoveIcon(
-            profilePictureUri = profilePictureUri.value,
-            onRemove = onProfilePictureUriChange
-        )
-    }
-
-    if (showSheet) {
-        ModalBottomSheet(
-            sheetState = sheetState,
-            onDismissRequest = { scope.launch { sheetState.hide(); showSheet=false } },
-            content = {
-                PictureSelectionTool(
-                    maxPictures = 1,
-                    allowGallery = true,
-                    allowCamera = true,
-                    onValidate = { uris ->
-                        if (uris.isNotEmpty()) {
-                            profilePictureUri.value = uris.first() // Use the first selected as the profile picture
-                        }
-                        scope.launch { sheetState.hide() }
-                        showSheet = false
-                    },
-                    onCancel = {
-                        scope.launch { sheetState.hide() }
-                        showSheet = false
-                    }
-                )
-            }
-        )
-    }
+                scope.launch { sheetState.hide() }
+                showSheet = false
+              },
+              onCancel = {
+                scope.launch { sheetState.hide() }
+                showSheet = false
+              })
+        })
+  }
 }
-
-
 
 @Composable
 fun InterestInputChip(pair: Pair<Interest, MutableState<Boolean>>, testTag: String) {

--- a/app/src/main/java/com/android/unio/ui/components/UserEditionComponents.kt
+++ b/app/src/main/java/com/android/unio/ui/components/UserEditionComponents.kt
@@ -112,7 +112,8 @@ fun ProfilePicturePicker(
               onCancel = {
                 scope.launch { sheetState.hide() }
                 showSheet = false
-              })
+              },
+              initialSelectedPictures = emptyList())
         })
   }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -137,6 +137,17 @@
     <string name="welcome_content_description_show_password">Montrer le mot de passe</string>
     <string name="welcome_forgot_password">Oublié votre mot de passe ?</string>
 
+    <!-- Picture Selection Tool Strings -->
+    <string name="selection_tool_selected_picture_text">Images sélectionnées</string>
+    <string name="selection_tool_remove_picture">Supprimer l\'image</string>
+    <string name="selection_tool_add_gallery_content_description">Ajouter depuis la galerie</string>
+    <string name="selection_tool_gallery_text">Galerie</string>
+    <string name="selection_tool_take_picture">Prendre une photo</string>
+    <string name="selection_tool_camera_text">Appareil photo</string>
+    <string name="selection_tool_validate_text">Valider</string>
+    <string name="selection_tool_cancel_text">Annuler</string>
+
+
     /**
     * package: event
     */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,16 @@
     <string name="welcome_content_description_show_password">Show password</string>
     <string name="welcome_forgot_password">Forgot your password ?</string>
 
+    <!-- Picture Selection Tool Strings -->
+    <string name="selection_tool_selected_picture_text">Selected Pictures</string>
+    <string name="selection_tool_remove_picture">Remove Picture</string>
+    <string name="selection_tool_add_gallery_content_description">Add from Gallery</string>
+    <string name="selection_tool_gallery_text">Gallery</string>
+    <string name="selection_tool_take_picture">Take Picture</string>
+    <string name="selection_tool_camera_text">Camera</string>
+    <string name="selection_tool_validate_text">Validate</string>
+    <string name="selection_tool_cancel_text">Cancel</string>
+
     /**
     * package: event
     */


### PR DESCRIPTION
This PR creates a picture selection tool and integrate it in the AccountDetails. 
The tool supports selecting multiple images with a maximum limit and provides options to validate or cancel the selection.

The composable displays selected images in a grid and enables the removal of individual selections, handles validation to confirm the selection and cancellation to reset the selection process, supports a dynamic maximum limit for the number of pictures to be selected.

It also uses the ModalBottomSheet to allow smooth and interactive image selection, as this creates a "pop-up" page that can be easily cancelled by clicking anywhere else on the screen.