### PR TITLE
Feat/event creation offline

### DIFF
--- a/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/association/AssociationProfileTest.kt
@@ -9,9 +9,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.getSystemService
-import androidx.navigation.NavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.android.unio.R
 import com.android.unio.TearDown
@@ -35,6 +35,7 @@ import com.android.unio.model.user.UserViewModel
 import com.android.unio.ui.association.AssociationProfileScaffold
 import com.android.unio.ui.association.AssociationProfileScreen
 import com.android.unio.ui.navigation.NavigationAction
+import com.android.unio.ui.navigation.Screen
 import com.google.android.gms.tasks.Task
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.CollectionReference
@@ -55,13 +56,13 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.verify
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
-import org.mockito.kotlin.verify
 
 @HiltAndroidTest
 @UninstallModules(FirebaseModule::class)
@@ -70,7 +71,7 @@ class AssociationProfileTest : TearDown() {
   private lateinit var associations: List<Association>
   private lateinit var events: List<Event>
 
-  private lateinit var navigationAction: NavigationAction
+  @MockK private lateinit var navigationAction: NavigationAction
   private lateinit var eventViewModel: EventViewModel
   private lateinit var userViewModel: UserViewModel
   private lateinit var associationViewModel: AssociationViewModel
@@ -110,6 +111,10 @@ class AssociationProfileTest : TearDown() {
     `when`(task.addOnSuccessListener(any())).thenReturn(task)
     `when`(task.addOnFailureListener(any())).thenReturn(task)
 
+    // Mock the navigation action to do nothing
+    every { navigationAction.navigateTo(any<String>()) } returns Unit
+    every { navigationAction.goBack() } returns Unit
+
     associations =
         listOf(
             MockAssociation.createMockAssociation(uid = "1"),
@@ -131,8 +136,6 @@ class AssociationProfileTest : TearDown() {
             socials = emptyList(),
             profilePicture = "",
         )
-
-    navigationAction = NavigationAction(mock(NavHostController::class.java))
 
     every { eventRepository.init(any()) } answers { (args[0] as () -> Unit).invoke() }
 
@@ -338,11 +341,9 @@ class AssociationProfileTest : TearDown() {
           navigationAction, userViewModel, eventViewModel, associationViewModel) {}
     }
 
-    `when`(navigationAction.navController.popBackStack()).thenReturn(true)
-
     composeTestRule.onNodeWithTag(AssociationProfileTestTags.GO_BACK_BUTTON).performClick()
 
-    verify(navigationAction.navController).popBackStack()
+    verify { navigationAction.goBack() }
   }
 
   @Test
@@ -369,6 +370,42 @@ class AssociationProfileTest : TearDown() {
     }
 
     composeTestRule.onNodeWithTag(AssociationProfileTestTags.SCREEN).assertIsNotDisplayed()
+  }
+
+  @Test
+  fun testAddEventButtonOnline() {
+    every { connectivityManager?.activeNetwork } returns mockk<Network>()
+
+    composeTestRule.setContent {
+      AssociationProfileScaffold(
+          navigationAction, userViewModel, eventViewModel, associationViewModel) {}
+    }
+
+    composeTestRule.onNodeWithTag(AssociationProfileTestTags.ADD_EVENT_BUTTON).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AssociationProfileTestTags.ADD_EVENT_BUTTON)
+        .performScrollTo()
+        .performClick()
+
+    verify { navigationAction.navigateTo(Screen.EVENT_CREATION) }
+  }
+
+  @Test
+  fun testAddEventButtonOffline() {
+    every { connectivityManager?.activeNetwork } returns null
+
+    composeTestRule.setContent {
+      AssociationProfileScaffold(
+          navigationAction, userViewModel, eventViewModel, associationViewModel) {}
+    }
+
+    composeTestRule.onNodeWithTag(AssociationProfileTestTags.ADD_EVENT_BUTTON).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AssociationProfileTestTags.ADD_EVENT_BUTTON)
+        .performScrollTo()
+        .performClick()
+
+    verify(exactly = 0) { navigationAction.navigateTo(Screen.EVENT_CREATION) }
   }
 
   @Module

--- a/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
+++ b/app/src/main/java/com/android/unio/ui/association/AssociationProfile.kt
@@ -458,6 +458,7 @@ private fun AssociationEvents(
     eventViewModel: EventViewModel
 ) {
   val context = LocalContext.current
+  val isConnected = Utils.checkInternetConnection(context)
 
   var isSeeMoreClicked by remember { mutableStateOf(false) }
 
@@ -496,7 +497,15 @@ private fun AssociationEvents(
   }
   if (isAdmin) {
     Button(
-        onClick = { navigationAction.navigateTo(Screen.EVENT_CREATION) },
+        onClick = {
+          if (isConnected) {
+            navigationAction.navigateTo(Screen.EVENT_CREATION)
+          } else {
+            Toast.makeText(
+                    context, context.getString(R.string.no_internet_connection), Toast.LENGTH_SHORT)
+                .show()
+          }
+        },
         modifier = Modifier.testTag(AssociationProfileTestTags.ADD_EVENT_BUTTON),
         contentPadding = ButtonDefaults.ButtonWithIconContentPadding) {
           Icon(


### PR DESCRIPTION
For full offline mode feature overview, see [this issue](https://github.com/SwEnt-Group13/Unio/issues/228).

For this specific feature, see the full description and the choice of solution behind it in [this issue](https://github.com/SwEnt-Group13/Unio/issues/248).

## Description
This PR implements a simple handling of the add event button in offline mode. When we click on it, it prevents the user from navigating to the event creation screen, which means the user isn't allowed to create one, just like a user on any social media wouldn't be allowed to create a post while offline.

## Motivation and context
This fix goes in the spirit of adapting our app's features for offline mode. This was one of the features that needed additional measures to respect it.

### AssociationProfile: 
- Added isOnline boolean that checks if the user is online or not.
- Added logic to the `Add event` button to display a toast that says the user is offline if it is the case.

## How has this been tested?

In AssociationProfileTest, I added two tests: 
- testAddEventButtonOnline: checks that the button click takes the user to the event creation screen.
- testAddEventButtonOffline: checks that the button click does *not* take the user to the event creation screen.