### PR TITLE
Fix/home sort event

### DIFF
--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -180,10 +180,10 @@ fun HomeContent(
       }
     } else {
       EventList(
-          navigationAction, searchResults.sortedBy { it.startDate }, userViewModel, eventViewModel)
+          navigationAction, searchResults.sortedWith(compareBy({ it.startDate }, { it.uid })), userViewModel, eventViewModel)
     }
   } else if (events.isNotEmpty()) {
-    EventList(navigationAction, events.sortedBy { it.startDate }, userViewModel, eventViewModel)
+    EventList(navigationAction, events.sortedWith(compareBy({ it.startDate }, { it.uid })), userViewModel, eventViewModel)
   } else {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       Text(

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -180,10 +180,17 @@ fun HomeContent(
       }
     } else {
       EventList(
-          navigationAction, searchResults.sortedWith(compareBy({ it.startDate }, { it.uid })), userViewModel, eventViewModel)
+          navigationAction,
+          searchResults.sortedWith(compareBy({ it.startDate }, { it.uid })),
+          userViewModel,
+          eventViewModel)
     }
   } else if (events.isNotEmpty()) {
-    EventList(navigationAction, events.sortedWith(compareBy({ it.startDate }, { it.uid })), userViewModel, eventViewModel)
+    EventList(
+        navigationAction,
+        events.sortedWith(compareBy({ it.startDate }, { it.uid })),
+        userViewModel,
+        eventViewModel)
   } else {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       Text(

--- a/app/src/main/java/com/android/unio/ui/home/Home.kt
+++ b/app/src/main/java/com/android/unio/ui/home/Home.kt
@@ -157,10 +157,11 @@ fun HomeContent(
         Text(context.getString(R.string.explore_search_no_results))
       }
     } else {
-      EventList(navigationAction, searchResults, userViewModel, eventViewModel)
+      EventList(
+          navigationAction, searchResults.sortedBy { it.startDate }, userViewModel, eventViewModel)
     }
   } else if (events.isNotEmpty()) {
-    EventList(navigationAction, events, userViewModel, eventViewModel)
+    EventList(navigationAction, events.sortedBy { it.startDate }, userViewModel, eventViewModel)
   } else {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       Text(

--- a/app/src/main/java/com/android/unio/ui/saved/Saved.kt
+++ b/app/src/main/java/com/android/unio/ui/saved/Saved.kt
@@ -61,7 +61,9 @@ fun SavedScreen(
 
   val allEvents by eventViewModel.events.collectAsState()
   val savedEvents by derivedStateOf {
-    allEvents.filter { user!!.savedEvents.contains(it.uid) }.sortedWith(compareBy({ it.startDate }, { it.uid }))
+    allEvents
+        .filter { user!!.savedEvents.contains(it.uid) }
+        .sortedWith(compareBy({ it.startDate }, { it.uid }))
   }
 
   val context = LocalContext.current

--- a/app/src/main/java/com/android/unio/ui/saved/Saved.kt
+++ b/app/src/main/java/com/android/unio/ui/saved/Saved.kt
@@ -53,7 +53,9 @@ fun SavedScreen(
   }
 
   val allEvents by eventViewModel.events.collectAsState()
-  val savedEvents by derivedStateOf { allEvents.filter { user!!.savedEvents.contains(it.uid) } }
+  val savedEvents by derivedStateOf {
+    allEvents.filter { user!!.savedEvents.contains(it.uid) }.sortedBy { it.startDate }
+  }
 
   val context = LocalContext.current
 

--- a/app/src/main/java/com/android/unio/ui/saved/Saved.kt
+++ b/app/src/main/java/com/android/unio/ui/saved/Saved.kt
@@ -61,7 +61,7 @@ fun SavedScreen(
 
   val allEvents by eventViewModel.events.collectAsState()
   val savedEvents by derivedStateOf {
-    allEvents.filter { user!!.savedEvents.contains(it.uid) }.sortedBy { it.startDate }
+    allEvents.filter { user!!.savedEvents.contains(it.uid) }.sortedWith(compareBy({ it.startDate }, { it.uid }))
   }
 
   val context = LocalContext.current


### PR DESCRIPTION
This small PR aims to fix the issue " The events in Home seem to be sorted in a random order, or if not random, certainly aren't sorted in chronological order" brought in #269. It does so by sorting the events before passing them to the event list to be displayed. I originally also wanted to fix the weird interaction when you unsave an event in Saved.kt, but this seems to be a data synchronization issue between the repository and the view model, and will therefore not be done in this PR.