### PR TITLE
Application crashes if we search then follow/save an event

### DIFF
--- a/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
@@ -20,7 +20,6 @@ import com.android.unio.model.user.UserSocial
  * @return Serialized Firestore data.
  */
 fun AssociationRepositoryFirestore.Companion.serialize(association: Association): Map<String, Any> {
-  println(mapRolesToPermission(association.roles))
   return mapOf(
       Association::uid.name to association.uid,
       Association::url.name to association.url,

--- a/app/src/main/java/com/android/unio/model/search/SearchRepository.kt
+++ b/app/src/main/java/com/android/unio/model/search/SearchRepository.kt
@@ -26,6 +26,7 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 
 /**
@@ -206,13 +207,19 @@ constructor(
     return suspendCoroutine { continuation ->
       associationRepository.getAssociationWithId(
           id = associationDocument.uid,
-          onSuccess = { association -> continuation.resume(association) },
+          onSuccess = { association ->
+            if (continuation.context.isActive) {
+              continuation.resume(association)
+            }
+          },
           onFailure = { exception ->
             Log.e(
                 "SearchRepository",
                 "failed to convert associationDocumentation to association ",
                 exception)
-            continuation.resumeWithException(exception)
+            if (continuation.context.isActive) {
+              continuation.resumeWithException(exception)
+            }
           })
     }
   }
@@ -227,10 +234,16 @@ constructor(
     return suspendCoroutine { continuation ->
       eventRepository.getEventWithId(
           id = eventDocument.uid,
-          onSuccess = { association -> continuation.resume(association) },
+          onSuccess = { association ->
+            if (continuation.context.isActive) {
+              continuation.resume(association)
+            }
+          },
           onFailure = { exception ->
             Log.e("SearchRepository", "failed to convert eventDocumentation to event ", exception)
-            continuation.resumeWithException(exception)
+            if (continuation.context.isActive) {
+              continuation.resumeWithException(exception)
+            }
           })
     }
   }

--- a/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/android/unio/model/search/SearchRepositoryTest.kt
@@ -69,11 +69,13 @@ class SearchRepositoryTest {
   private val testScope = TestScope(testDispatcher)
 
   @MockK private lateinit var firebaseAuth: FirebaseAuth
+
   @MockK private lateinit var firebaseUser: FirebaseUser
 
   @MockK private lateinit var mockSession: AppSearchSession
 
   @MockK private lateinit var mockAssociationRepository: AssociationRepository
+
   @MockK private lateinit var mockEventRepository: EventRepository
 
   private lateinit var searchRepository: SearchRepository


### PR DESCRIPTION
Another issue is encountered with the application. When first searching for an event or a association, or more generally, when we use the searchViewModel, and then we try to follow/save an event, an unexpected crash happens.
This is the error message the we get in the log cat :

  ```
  Process: com.android.unio, PID: 26561
    java.lang.IllegalStateException: Already resumed
    	at kotlin.coroutines.SafeContinuation.resumeWith(SafeContinuationJvm.kt:44)
	at com.android.unio.model.search.SearchRepository$eventDocumentToEvent$2$1.invoke(SearchRepository.kt:216)
	at com.android.unio.model.search.SearchRepository$eventDocumentToEvent$2$1.invoke(SearchRepository.kt:214)
	at com.android.unio.model.event.EventRepositoryFirestore.getEventWithId$lambda$1(EventRepositoryFirestore.kt:65)
    	at com.android.unio.model.event.EventRepositoryFirestore.$r8$lambda$mHghD2Dd1GuRYS7HdibPomGrHjs(Unknown Source:0)
	at com.android.unio.model.event.EventRepositoryFirestore$$ExternalSyntheticLambda2.onEvent(D8$$SyntheticClass:0)
    	at com.google.firebase.firestore.DocumentReference.lambda$addSnapshotListenerInternal$6$com-google-firebase-firestore-DocumentReference(DocumentReference.java:525)
    	at com.google.firebase.firestore.DocumentReference$$ExternalSyntheticLambda5.onEvent(D8$$SyntheticClass:0)
    	at com.google.firebase.firestore.core.AsyncEventListener.lambda$onEvent$0$com-google-firebase-firestore-core-AsyncEventListener(AsyncEventListener.java:42)
    	at com.google.firebase.firestore.core.AsyncEventListener$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
    	at android.os.Handler.handleCallback(Handler.java:958)
    	at android.os.Handler.dispatchMessage(Handler.java:99)
    	at android.os.Looper.loopOnce(Looper.java:257)
    	at android.os.Looper.loop(Looper.java:368)
    	at android.app.ActivityThread.main(ActivityThread.java:8826)
    	at java.lang.reflect.Method.invoke(Native Method)
    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:572)
    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1049)
```

It seems that every time we use the search view model, (even inputting a single character) all other Firebase will fail.