### PR TITLE
Rework Claim Association

### DIFF
--- a/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.navigation.NavHostController
 import com.android.unio.TearDown
+import com.android.unio.assertDisplayComponentInScroll
 import com.android.unio.model.association.AssociationRepositoryFirestore
 import com.android.unio.model.association.AssociationViewModel
 import com.android.unio.model.event.EventRepositoryFirestore
@@ -13,6 +14,7 @@ import com.android.unio.model.follow.ConcurrentAssociationUserRepositoryFirestor
 import com.android.unio.model.image.ImageRepositoryFirebaseStorage
 import com.android.unio.model.search.SearchRepository
 import com.android.unio.model.search.SearchViewModel
+import com.android.unio.model.strings.test_tags.explore.ExploreContentTestTags
 import com.android.unio.model.strings.test_tags.user.UserClaimAssociationTestTags
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.user.UserClaimAssociationScreen
@@ -69,8 +71,9 @@ class UserClaimAssociationTest : TearDown() {
       UserClaimAssociationScreen(associationViewModel, navigationAction, searchViewModel)
     }
 
-    composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.SCREEN).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.SCREEN).assertDisplayComponentInScroll()
+    composeTestRule.onNodeWithTag(ExploreContentTestTags.SEARCH_BAR_INPUT).assertDisplayComponentInScroll()
+    composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON).assertDisplayComponentInScroll()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
@@ -1,6 +1,5 @@
 package com.android.unio.components.user
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -71,9 +70,15 @@ class UserClaimAssociationTest : TearDown() {
       UserClaimAssociationScreen(associationViewModel, navigationAction, searchViewModel)
     }
 
-    composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.SCREEN).assertDisplayComponentInScroll()
-    composeTestRule.onNodeWithTag(ExploreContentTestTags.SEARCH_BAR_INPUT).assertDisplayComponentInScroll()
-    composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON).assertDisplayComponentInScroll()
+    composeTestRule
+        .onNodeWithTag(UserClaimAssociationTestTags.SCREEN)
+        .assertDisplayComponentInScroll()
+    composeTestRule
+        .onNodeWithTag(ExploreContentTestTags.SEARCH_BAR_INPUT)
+        .assertDisplayComponentInScroll()
+    composeTestRule
+        .onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON)
+        .assertDisplayComponentInScroll()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
@@ -58,8 +58,8 @@ class UserClaimAssociationTest : TearDown() {
 
     every { navigationAction.navigateTo(any<String>()) } returns Unit
 
-      mockkStatic(FocusRequester::class)
-      every { focusRequester.requestFocus()} just Runs
+    mockkStatic(FocusRequester::class)
+    every { focusRequester.requestFocus() } just Runs
 
     associationViewModel =
         AssociationViewModel(
@@ -95,7 +95,9 @@ class UserClaimAssociationTest : TearDown() {
     composeTestRule.setContent {
       UserClaimAssociationScreen(associationViewModel, navigationAction, searchViewModel)
     }
-      composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON).assertDisplayComponentInScroll()
+    composeTestRule
+        .onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON)
+        .assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON).performClick()
   }
 }

--- a/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
@@ -1,5 +1,6 @@
 package com.android.unio.components.user
 
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -20,8 +21,11 @@ import com.android.unio.ui.user.UserClaimAssociationScreen
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.MockKAnnotations
+import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockkStatic
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,6 +45,8 @@ class UserClaimAssociationTest : TearDown() {
   @MockK private lateinit var searchRepository: SearchRepository
   @MockK private lateinit var navHostController: NavHostController
 
+  @MockK private lateinit var focusRequester: FocusRequester
+
   @MockK private lateinit var navigationAction: NavigationAction
   private lateinit var associationViewModel: AssociationViewModel
   private lateinit var searchViewModel: SearchViewModel
@@ -51,6 +57,9 @@ class UserClaimAssociationTest : TearDown() {
     hiltRule.inject()
 
     every { navigationAction.navigateTo(any<String>()) } returns Unit
+
+      mockkStatic(FocusRequester::class)
+      every { focusRequester.requestFocus()} just Runs
 
     associationViewModel =
         AssociationViewModel(
@@ -86,7 +95,7 @@ class UserClaimAssociationTest : TearDown() {
     composeTestRule.setContent {
       UserClaimAssociationScreen(associationViewModel, navigationAction, searchViewModel)
     }
-
+      composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON).assertDisplayComponentInScroll()
     composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON).performClick()
   }
 }

--- a/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
+++ b/app/src/androidTest/java/com/android/unio/components/user/UserClaimAssociationTest.kt
@@ -71,9 +71,6 @@ class UserClaimAssociationTest : TearDown() {
 
     composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.SCREEN).assertIsDisplayed()
     composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag(UserClaimAssociationTestTags.NEW_ASSOCIATION_BUTTON)
-        .assertIsDisplayed()
   }
 
   @Test
@@ -83,15 +80,5 @@ class UserClaimAssociationTest : TearDown() {
     }
 
     composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.BACK_BUTTON).performClick()
-  }
-
-  @Test
-  fun testCreateNewAssociationButtonShowsToast() {
-    composeTestRule.setContent {
-      UserClaimAssociationScreen(associationViewModel, navigationAction, searchViewModel)
-    }
-
-    val button = composeTestRule.onNodeWithTag(UserClaimAssociationTestTags.NEW_ASSOCIATION_BUTTON)
-    button.performClick()
   }
 }

--- a/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/transform/Serialization.kt
@@ -41,7 +41,7 @@ fun AssociationRepositoryFirestore.Companion.serialize(association: Association)
  * @param members Members to map.
  * @return Map of user UIDs to role UIDs.
  */
-fun mapUsersToRoles(members: List<Member>): Map<String, String> {
+private fun mapUsersToRoles(members: List<Member>): Map<String, String> {
   return members.associate { member -> member.user.uid to member.role.uid }
 }
 
@@ -51,7 +51,7 @@ fun mapUsersToRoles(members: List<Member>): Map<String, String> {
  * @param roles Roles to map.
  * @return Map of role UIDs to role data.
  */
-fun mapRolesToPermission(roles: List<Role>): Map<String, Map<String, Any>> {
+private fun mapRolesToPermission(roles: List<Role>): Map<String, Map<String, Any>> {
   return roles.associate { role ->
     role.uid to
         mapOf(

--- a/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
+++ b/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.unio.R

--- a/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
+++ b/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
@@ -50,7 +50,6 @@ fun UserClaimAssociationScreen(
   val context = LocalContext.current
 
   val focusRequester = remember { FocusRequester() }
-  val focusManager = LocalFocusManager.current
 
   LaunchedEffect(Unit) { focusRequester.requestFocus() }
 

--- a/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
+++ b/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -27,7 +26,6 @@ import com.android.unio.ui.association.AssociationSearchBar
 import com.android.unio.ui.navigation.NavigationAction
 import com.android.unio.ui.navigation.Screen
 import com.android.unio.ui.theme.AppTypography
-import com.android.unio.ui.utils.ToastUtils
 
 /**
  * Composable allows the user to search for an association and one.
@@ -66,26 +64,12 @@ fun UserClaimAssociationScreen(
         ) {
           Column(
               modifier = Modifier.padding(16.dp),
-              verticalArrangement = Arrangement.spacedBy(6.dp),
+              verticalArrangement = Arrangement.spacedBy(12.dp),
               horizontalAlignment = Alignment.CenterHorizontally,
           ) {
             Text(
-                context.getString(R.string.user_claim_association_you_can_either),
+                context.getString(R.string.user_claim_association_you_can_do_the_following),
                 style = AppTypography.headlineSmall)
-
-            Text(
-                context.getString(R.string.user_claim_association_create_new_association),
-                style = AppTypography.bodySmall)
-
-            Button(
-                onClick = {
-                  ToastUtils.showToast(
-                      context,
-                      context.getString(R.string.user_claim_association_not_implemented_yet))
-                },
-                modifier = Modifier.testTag(UserClaimAssociationTestTags.NEW_ASSOCIATION_BUTTON)) {
-                  Text(context.getString(R.string.user_claim_association_create_association))
-                }
 
             Text(
                 context.getString(R.string.user_claim_association_claim_president_rights),

--- a/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
+++ b/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
@@ -15,7 +15,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -47,10 +49,6 @@ fun UserClaimAssociationScreen(
     searchViewModel: SearchViewModel
 ) {
   val context = LocalContext.current
-
-  val focusRequester = remember { FocusRequester() }
-
-  LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
   Scaffold(
       modifier = Modifier.testTag(UserClaimAssociationTestTags.SCREEN),
@@ -84,6 +82,10 @@ fun UserClaimAssociationScreen(
             Text(
                 context.getString(R.string.user_claim_association_claim_president_rights),
                 style = AppTypography.bodySmall)
+
+            val focusRequester = remember { FocusRequester() }
+
+            LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
             Box(modifier = Modifier.focusRequester(focusRequester)) {
               AssociationSearchBar(

--- a/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
+++ b/app/src/main/java/com/android/unio/ui/user/UserClaimAssociation.kt
@@ -1,6 +1,7 @@
 package com.android.unio.ui.user
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -13,9 +14,14 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.unio.R
@@ -42,6 +48,12 @@ fun UserClaimAssociationScreen(
     searchViewModel: SearchViewModel
 ) {
   val context = LocalContext.current
+
+  val focusRequester = remember { FocusRequester() }
+  val focusManager = LocalFocusManager.current
+
+  LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
   Scaffold(
       modifier = Modifier.testTag(UserClaimAssociationTestTags.SCREEN),
       topBar = {
@@ -75,14 +87,16 @@ fun UserClaimAssociationScreen(
                 context.getString(R.string.user_claim_association_claim_president_rights),
                 style = AppTypography.bodySmall)
 
-            AssociationSearchBar(
-                searchViewModel = searchViewModel,
-                onAssociationSelected = { association ->
-                  associationViewModel.selectAssociation(association.uid)
-                  navigationAction.navigateTo(Screen.CLAIM_ASSOCIATION_PRESIDENTIAL_RIGHTS)
-                },
-                false,
-                {})
+            Box(modifier = Modifier.focusRequester(focusRequester)) {
+              AssociationSearchBar(
+                  searchViewModel = searchViewModel,
+                  onAssociationSelected = { association ->
+                    associationViewModel.selectAssociation(association.uid)
+                    navigationAction.navigateTo(Screen.CLAIM_ASSOCIATION_PRESIDENTIAL_RIGHTS)
+                  },
+                  false,
+                  {})
+            }
           }
         }
       })

--- a/app/src/main/java/com/android/unio/ui/user/UserClaimAssociationPresidentialRights.kt
+++ b/app/src/main/java/com/android/unio/ui/user/UserClaimAssociationPresidentialRights.kt
@@ -3,13 +3,12 @@ package com.android.unio.ui.user
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -26,6 +25,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -106,22 +106,16 @@ fun UserClaimAssociationPresidentialRightsScreenScaffold(
                         imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
                         contentDescription = context.getString(R.string.association_go_back))
                   }
-            },
-            actions = {
-              Row {
-                IconButton(onClick = {}) {
-                  Icon(
-                      Icons.Outlined.MoreVert,
-                      contentDescription = context.getString(R.string.association_see_more))
-                }
-              }
             })
       },
       content = { padding ->
         Surface(
-            modifier = Modifier.padding(padding),
+            modifier = Modifier.fillMaxWidth().padding(padding),
         ) {
-          Column(modifier = Modifier.padding(16.dp)) {
+          Column(
+              modifier = Modifier.padding(16.dp),
+              horizontalAlignment = Alignment.CenterHorizontally,
+          ) {
             Text(
                 context.getString(
                     R.string.user_claim_association_presidential_rights_claim_presidential_rights),

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -313,7 +313,7 @@
     <!-- UserClaimAssociation Strings -->
     <string name="user_claim_association_association_go_back">Retour</string>
     <string name="user_claim_association_association_see_more">Voir plus</string>
-    <string name="user_claim_association_you_can_either">Vous pouvez soit</string>
+    <string name="user_claim_association_you_can_do_the_following">Vous pouvez procéder comme suit</string>
     <string name="user_claim_association_create_new_association">Créer une nouvelle association</string>
     <string name="user_claim_association_not_implemented_yet">Pas encore implémenté</string>
     <string name="user_claim_association_create_association">Créer une association</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -345,7 +345,7 @@
     <!-- UserClaimAssociation Strings -->
     <string name="user_claim_association_association_go_back">Go back</string>
     <string name="user_claim_association_association_see_more">See more</string>
-    <string name="user_claim_association_you_can_either">You can either</string>
+    <string name="user_claim_association_you_can_do_the_following">You can do the following</string>
     <string name="user_claim_association_create_new_association">Create a new association</string>
     <string name="user_claim_association_not_implemented_yet">Not implemented yet</string>
     <string name="user_claim_association_create_association">Create association</string>

--- a/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
+++ b/app/src/test/java/com/android/unio/model/firestore/HydrationAndSerializationTest.kt
@@ -10,8 +10,6 @@ import com.android.unio.model.association.compareRoleLists
 import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepositoryFirestore
 import com.android.unio.model.firestore.transform.hydrate
-import com.android.unio.model.firestore.transform.mapRolesToPermission
-import com.android.unio.model.firestore.transform.mapUsersToRoles
 import com.android.unio.model.firestore.transform.serialize
 import com.android.unio.model.map.Location
 import com.android.unio.model.user.Interest
@@ -116,8 +114,18 @@ class HydrationAndSerializationTest {
     assertEquals(association.name, serialized["name"])
     assertEquals(association.fullName, serialized["fullName"])
     assertEquals(association.description, serialized["description"])
-    assertEquals(mapUsersToRoles(association.members), serialized["members"])
-    assertEquals(mapRolesToPermission(association.roles), serialized["roles"])
+    assertEquals(
+        association.members.associate { member -> member.user.uid to member.role.uid },
+        serialized["members"])
+    assertEquals(
+        association.roles.associate { role ->
+          role.uid to
+              mapOf(
+                  Role::displayName.name to role.displayName,
+                  Role::permissions.name to
+                      role.permissions.getGrantedPermissions().map { it.stringName })
+        },
+        serialized["roles"])
     assertEquals(association.image, serialized["image"])
     assertEquals(association.events.uids, serialized["events"])
 


### PR DESCRIPTION
From #269. Some components in the "Claim Association" page behave not like expected. This task aims to correct this. Precisely, this means :

- The three dots top right do not do anything, and should be removed
- The search bar should be enabled by default, as it makes no sense for it to be toggled off. Or if for some reason it does make sense the logic for it should be implemented
- Create association" is currently unimplemented and should be removed