### PR TITLE
Fix/add delete event local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ local.properties
 *.log
 node_modules/
 firebase/tests/coverage/
+/misc/.env

--- a/app/src/main/java/com/android/unio/mocks/firestore/MockReferenceList.kt
+++ b/app/src/main/java/com/android/unio/mocks/firestore/MockReferenceList.kt
@@ -12,6 +12,7 @@ class MockReferenceList<T : UniquelyIdentifiable>(elements: List<T> = emptyList(
   override val uids: List<String> = elements.map { it.uid }
 
   override fun add(uid: String) {}
+
   override fun add(element: T) {}
 
   override fun addAll(uids: List<String>) {}

--- a/app/src/main/java/com/android/unio/mocks/firestore/MockReferenceList.kt
+++ b/app/src/main/java/com/android/unio/mocks/firestore/MockReferenceList.kt
@@ -12,6 +12,7 @@ class MockReferenceList<T : UniquelyIdentifiable>(elements: List<T> = emptyList(
   override val uids: List<String> = elements.map { it.uid }
 
   override fun add(uid: String) {}
+  override fun add(element: T) {}
 
   override fun addAll(uids: List<String>) {}
 

--- a/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
@@ -2,6 +2,7 @@ package com.android.unio.model.association
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import com.android.unio.model.event.Event
 import com.android.unio.model.event.EventRepository
 import com.android.unio.model.follow.ConcurrentAssociationUserRepository
 import com.android.unio.model.image.ImageRepository
@@ -133,7 +134,48 @@ constructor(
         { exception -> Log.e("AssociationViewModel", "Failed to update follow", exception) })
   }
 
-  /**
+    /**
+     * Deletes an event from the events list of the selected association locally.
+     *
+     * @param eventId The ID of the event to be deleted.
+     */
+    fun deleteEventLocally(eventId: String) {
+        val selectedAssociation = _selectedAssociation.value
+        if (selectedAssociation != null) {
+            val eventToDelete = selectedAssociation.events.uids.find { it == eventId }
+            // if event exists ->  remove it from the events list
+            if (eventToDelete != null) {
+                selectedAssociation.events.remove(eventId) //check the definition of remove to see that it does not fetch the database ; )
+            } else {
+                Log.e("AssociationViewModel", "Event with ID $eventId not found")
+            }
+        } else {
+            Log.e("AssociationViewModel", "No association selected to delete event from")
+        }
+    }
+
+    /**
+     * Adds an event to the events list of the selected association locally.
+     *
+     * @param eventId The ID of the event to be added.
+     */
+    fun addEventLocally(event: Event) {
+        val selectedAssociation = _selectedAssociation.value
+        if (selectedAssociation != null) {
+            val eventAlreadyExists = selectedAssociation.events.uids.contains(event.uid)
+            // Check if the event already exists in the events list
+            if (!eventAlreadyExists) {
+                selectedAssociation.events.add(event) // Ensure `add` does not fetch the database
+            } else {
+                Log.w("AssociationViewModel", "Event with ID ${event.uid} already exists")
+            }
+        } else {
+            Log.e("AssociationViewModel", "No association selected to add event to")
+        }
+    }
+
+
+    /**
    * Saves an association to the repository. If an image stream is provided, the image is uploaded
    * to Firebase Storage and the image URL is saved to the association. If the image stream is null,
    * the association is saved without an image.

--- a/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
@@ -147,7 +147,7 @@ constructor(
       if (eventToDelete != null) {
         selectedAssociation.events.remove(
             eventId) // check the definition of remove to see that it does not fetch the database ;
-                     // )
+        // )
       } else {
         Log.e("AssociationViewModel", "Event with ID $eventId not found")
       }

--- a/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
@@ -159,7 +159,7 @@ constructor(
   /**
    * Adds an event to the events list of the selected association locally.
    *
-   * @param eventId The ID of the event to be added.
+   * @param event The event to be added.
    */
   fun addEventLocally(event: Event) {
     val selectedAssociation = _selectedAssociation.value

--- a/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
+++ b/app/src/main/java/com/android/unio/model/association/AssociationViewModel.kt
@@ -134,48 +134,49 @@ constructor(
         { exception -> Log.e("AssociationViewModel", "Failed to update follow", exception) })
   }
 
-    /**
-     * Deletes an event from the events list of the selected association locally.
-     *
-     * @param eventId The ID of the event to be deleted.
-     */
-    fun deleteEventLocally(eventId: String) {
-        val selectedAssociation = _selectedAssociation.value
-        if (selectedAssociation != null) {
-            val eventToDelete = selectedAssociation.events.uids.find { it == eventId }
-            // if event exists ->  remove it from the events list
-            if (eventToDelete != null) {
-                selectedAssociation.events.remove(eventId) //check the definition of remove to see that it does not fetch the database ; )
-            } else {
-                Log.e("AssociationViewModel", "Event with ID $eventId not found")
-            }
-        } else {
-            Log.e("AssociationViewModel", "No association selected to delete event from")
-        }
+  /**
+   * Deletes an event from the events list of the selected association locally.
+   *
+   * @param eventId The ID of the event to be deleted.
+   */
+  fun deleteEventLocally(eventId: String) {
+    val selectedAssociation = _selectedAssociation.value
+    if (selectedAssociation != null) {
+      val eventToDelete = selectedAssociation.events.uids.find { it == eventId }
+      // if event exists ->  remove it from the events list
+      if (eventToDelete != null) {
+        selectedAssociation.events.remove(
+            eventId) // check the definition of remove to see that it does not fetch the database ;
+                     // )
+      } else {
+        Log.e("AssociationViewModel", "Event with ID $eventId not found")
+      }
+    } else {
+      Log.e("AssociationViewModel", "No association selected to delete event from")
     }
+  }
 
-    /**
-     * Adds an event to the events list of the selected association locally.
-     *
-     * @param eventId The ID of the event to be added.
-     */
-    fun addEventLocally(event: Event) {
-        val selectedAssociation = _selectedAssociation.value
-        if (selectedAssociation != null) {
-            val eventAlreadyExists = selectedAssociation.events.uids.contains(event.uid)
-            // Check if the event already exists in the events list
-            if (!eventAlreadyExists) {
-                selectedAssociation.events.add(event) // Ensure `add` does not fetch the database
-            } else {
-                Log.w("AssociationViewModel", "Event with ID ${event.uid} already exists")
-            }
-        } else {
-            Log.e("AssociationViewModel", "No association selected to add event to")
-        }
+  /**
+   * Adds an event to the events list of the selected association locally.
+   *
+   * @param eventId The ID of the event to be added.
+   */
+  fun addEventLocally(event: Event) {
+    val selectedAssociation = _selectedAssociation.value
+    if (selectedAssociation != null) {
+      val eventAlreadyExists = selectedAssociation.events.uids.contains(event.uid)
+      // Check if the event already exists in the events list
+      if (!eventAlreadyExists) {
+        selectedAssociation.events.add(event) // Ensure `add` does not fetch the database
+      } else {
+        Log.w("AssociationViewModel", "Event with ID ${event.uid} already exists")
+      }
+    } else {
+      Log.e("AssociationViewModel", "No association selected to add event to")
     }
+  }
 
-
-    /**
+  /**
    * Saves an association to the repository. If an image stream is provided, the image is uploaded
    * to Firebase Storage and the image URL is saved to the association. If the image stream is null,
    * the association is saved without an image.

--- a/app/src/main/java/com/android/unio/model/firestore/FirestoreReferenceList.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/FirestoreReferenceList.kt
@@ -60,6 +60,17 @@ class FirestoreReferenceList<T : UniquelyIdentifiable>(
     _uids.add(uid)
   }
 
+    /**
+     * Adds an element to the list.
+     *
+     * @param element The element to add.
+     */
+    override fun add(element : T){
+        add(element.uid)
+        Log.d("DELETEEVENTLOCALLY", "je rajoute ${element.uid}")
+        _list.value += element
+    }
+
   /**
    * Adds a list of UIDs to the list.
    *
@@ -75,7 +86,9 @@ class FirestoreReferenceList<T : UniquelyIdentifiable>(
    * @param uid The UID to remove.
    */
   override fun remove(uid: String) {
-    _uids.remove(uid)
+      if (_uids.remove(uid)) {
+          _list.value = _list.value.filter { it.uid != uid }
+      }
   }
 
   /**

--- a/app/src/main/java/com/android/unio/model/firestore/FirestoreReferenceList.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/FirestoreReferenceList.kt
@@ -67,7 +67,6 @@ class FirestoreReferenceList<T : UniquelyIdentifiable>(
    */
   override fun add(element: T) {
     add(element.uid)
-    Log.d("DELETEEVENTLOCALLY", "je rajoute ${element.uid}")
     _list.value += element
   }
 

--- a/app/src/main/java/com/android/unio/model/firestore/FirestoreReferenceList.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/FirestoreReferenceList.kt
@@ -60,16 +60,16 @@ class FirestoreReferenceList<T : UniquelyIdentifiable>(
     _uids.add(uid)
   }
 
-    /**
-     * Adds an element to the list.
-     *
-     * @param element The element to add.
-     */
-    override fun add(element : T){
-        add(element.uid)
-        Log.d("DELETEEVENTLOCALLY", "je rajoute ${element.uid}")
-        _list.value += element
-    }
+  /**
+   * Adds an element to the list.
+   *
+   * @param element The element to add.
+   */
+  override fun add(element: T) {
+    add(element.uid)
+    Log.d("DELETEEVENTLOCALLY", "je rajoute ${element.uid}")
+    _list.value += element
+  }
 
   /**
    * Adds a list of UIDs to the list.
@@ -86,9 +86,9 @@ class FirestoreReferenceList<T : UniquelyIdentifiable>(
    * @param uid The UID to remove.
    */
   override fun remove(uid: String) {
-      if (_uids.remove(uid)) {
-          _list.value = _list.value.filter { it.uid != uid }
-      }
+    if (_uids.remove(uid)) {
+      _list.value = _list.value.filter { it.uid != uid }
+    }
   }
 
   /**

--- a/app/src/main/java/com/android/unio/model/firestore/ReferenceList.kt
+++ b/app/src/main/java/com/android/unio/model/firestore/ReferenceList.kt
@@ -8,6 +8,8 @@ interface ReferenceList<T> {
 
   fun add(uid: String)
 
+  fun add(element: T)
+
   fun addAll(uids: List<String>)
 
   fun remove(uid: String)

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -283,32 +283,36 @@ fun EventCreationScreen(
                       selectedLocation != null,
               onClick = {
                 val inputStream = context.contentResolver.openInputStream(eventBannerUri.value)!!
-                  val newEvent = Event(
-                      uid = "", // This gets overwritten by eventViewModel.addEvent
-                      title = name,
-                      organisers =
-                      Association.firestoreReferenceListWith(
-                          (coauthorsAndBoolean
-                              .filter { it.second.value }
-                              .map { it.first.uid } +
-                                  associationViewModel.selectedAssociation.value!!.uid)
-                              .distinct()),
-                      taggedAssociations =
-                      Association.firestoreReferenceListWith(
-                          taggedAndBoolean.filter { it.second.value }.map { it.first.uid }),
-                      image = eventBannerUri.value.toString(),
-                      description = longDescription,
-                      catchyDescription = shortDescription,
-                      price = 0.0,
-                      startDate = startTimestamp!!,
-                      endDate = endTimestamp!!,
-                      location = selectedLocation!!,
-                      eventPictures = MockReferenceList(),
-                  )
+                val newEvent =
+                    Event(
+                        uid = "", // This gets overwritten by eventViewModel.addEvent
+                        title = name,
+                        organisers =
+                            Association.firestoreReferenceListWith(
+                                (coauthorsAndBoolean
+                                        .filter { it.second.value }
+                                        .map { it.first.uid } +
+                                        associationViewModel.selectedAssociation.value!!.uid)
+                                    .distinct()),
+                        taggedAssociations =
+                            Association.firestoreReferenceListWith(
+                                taggedAndBoolean.filter { it.second.value }.map { it.first.uid }),
+                        image = eventBannerUri.value.toString(),
+                        description = longDescription,
+                        catchyDescription = shortDescription,
+                        price = 0.0,
+                        startDate = startTimestamp!!,
+                        endDate = endTimestamp!!,
+                        location = selectedLocation!!,
+                        eventPictures = MockReferenceList(),
+                    )
                 eventViewModel.addEvent(
                     inputStream,
                     newEvent,
-                    onSuccess = { associationViewModel.addEventLocally(newEvent); navigationAction.goBack() },
+                    onSuccess = {
+                      associationViewModel.addEventLocally(newEvent)
+                      navigationAction.goBack()
+                    },
                     onFailure = {
                       Toast.makeText(
                               context,

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -283,31 +283,32 @@ fun EventCreationScreen(
                       selectedLocation != null,
               onClick = {
                 val inputStream = context.contentResolver.openInputStream(eventBannerUri.value)!!
+                  val newEvent = Event(
+                      uid = "", // This gets overwritten by eventViewModel.addEvent
+                      title = name,
+                      organisers =
+                      Association.firestoreReferenceListWith(
+                          (coauthorsAndBoolean
+                              .filter { it.second.value }
+                              .map { it.first.uid } +
+                                  associationViewModel.selectedAssociation.value!!.uid)
+                              .distinct()),
+                      taggedAssociations =
+                      Association.firestoreReferenceListWith(
+                          taggedAndBoolean.filter { it.second.value }.map { it.first.uid }),
+                      image = eventBannerUri.value.toString(),
+                      description = longDescription,
+                      catchyDescription = shortDescription,
+                      price = 0.0,
+                      startDate = startTimestamp!!,
+                      endDate = endTimestamp!!,
+                      location = selectedLocation!!,
+                      eventPictures = MockReferenceList(),
+                  )
                 eventViewModel.addEvent(
                     inputStream,
-                    Event(
-                        uid = "", // This gets overwritten by eventViewModel.addEvent
-                        title = name,
-                        organisers =
-                            Association.firestoreReferenceListWith(
-                                (coauthorsAndBoolean
-                                        .filter { it.second.value }
-                                        .map { it.first.uid } +
-                                        associationViewModel.selectedAssociation.value!!.uid)
-                                    .distinct()),
-                        taggedAssociations =
-                            Association.firestoreReferenceListWith(
-                                taggedAndBoolean.filter { it.second.value }.map { it.first.uid }),
-                        image = eventBannerUri.value.toString(),
-                        description = longDescription,
-                        catchyDescription = shortDescription,
-                        price = 0.0,
-                        startDate = startTimestamp!!,
-                        endDate = endTimestamp!!,
-                        location = selectedLocation!!,
-                        eventPictures = MockReferenceList(),
-                    ),
-                    onSuccess = { navigationAction.goBack() },
+                    newEvent,
+                    onSuccess = { associationViewModel.addEventLocally(newEvent); navigationAction.goBack() },
                     onFailure = {
                       Toast.makeText(
                               context,

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -244,7 +244,10 @@ fun EventEditScreen(
                       // A dialog should be added to prevent accidental deletion
                       eventViewModel.deleteEvent(
                           eventToEdit,
-                          onSuccess = { associationViewModel.deleteEventLocally(eventToEdit.uid); navigationAction.goBack() },
+                          onSuccess = {
+                            associationViewModel.deleteEventLocally(eventToEdit.uid)
+                            navigationAction.goBack()
+                          },
                           onFailure = {
                             Toast.makeText(
                                     context,

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -244,7 +244,7 @@ fun EventEditScreen(
                       // A dialog should be added to prevent accidental deletion
                       eventViewModel.deleteEvent(
                           eventToEdit,
-                          onSuccess = { navigationAction.goBack() },
+                          onSuccess = { associationViewModel.deleteEventLocally(eventToEdit.uid); navigationAction.goBack() },
                           onFailure = {
                             Toast.makeText(
                                     context,


### PR DESCRIPTION
This PR fixes a bug that is that the just added event and the just deleted event are not immediately visible in the UI. It should be coupled with a force fetch that @oskar-codes did in #297. 

But as this is done here, it saves us from doing an unnecessary request to the db, as we already have the event we push to the db (no need to fetch it again) and it saves us from fetching all the event list to delete an event (we call also do it locally).