### PR TITLE
Add highlighting to missing inputs in Event creation and Event edition

### DIFF
--- a/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
+++ b/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
@@ -271,6 +271,12 @@ fun DateAndTimePicker(
                 ?: "",
         readOnly = true,
         onValueChange = {},
+        isError = selectedDate == null && initialDate == null,
+        supportingText = {
+          if (selectedDate == null && initialDate == null) {
+            Text(context.getString(R.string.event_edit_date_error))
+          }
+        },
         trailingIcon = {
           Icon(
               Icons.Default.DateRange,
@@ -299,6 +305,12 @@ fun DateAndTimePicker(
                 ?: "",
         readOnly = true,
         onValueChange = {},
+        isError = selectedTime == null && initialTime == null,
+        supportingText = {
+          if (selectedTime == null && initialTime == null) {
+            Text(context.getString(R.string.event_edit_time_error))
+          }
+        },
         trailingIcon = {
           Icon(
               Icons.Default.AccessTime,

--- a/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
+++ b/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
@@ -98,11 +98,11 @@ fun NominatimLocationPicker(
   var showDropdown by remember { mutableStateOf(false) }
 
   var shouldDisplayInitialLocation by remember { mutableStateOf(true) }
-    var selectedLocation by remember { mutableStateOf(initialLocation) }
+  var selectedLocation by remember { mutableStateOf(initialLocation) }
   val isError by remember {
-      derivedStateOf {
-          selectedLocation == null || selectedLocation!!.name.isEmpty() && locationQuery.isEmpty()
-   }
+    derivedStateOf {
+      selectedLocation == null || selectedLocation!!.name.isEmpty() && locationQuery.isEmpty()
+    }
   }
 
   Box(modifier = Modifier.fillMaxWidth()) {
@@ -110,7 +110,7 @@ fun NominatimLocationPicker(
         value = if (shouldDisplayInitialLocation) initialLocation?.name ?: "" else locationQuery,
         onValueChange = {
           locationSearchViewModel.setQuery(it)
-            selectedLocation = null
+          selectedLocation = null
           shouldDisplayInitialLocation = false
           showDropdown = true
         },
@@ -143,7 +143,7 @@ fun NominatimLocationPicker(
                 },
                 onClick = {
                   locationSearchViewModel.setQuery(location.name)
-                    selectedLocation = location
+                  selectedLocation = location
                   onLocationSelected(location)
                   showDropdown = false
                 },

--- a/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
+++ b/app/src/main/java/com/android/unio/ui/components/EventEditComponents.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -97,14 +98,27 @@ fun NominatimLocationPicker(
   var showDropdown by remember { mutableStateOf(false) }
 
   var shouldDisplayInitialLocation by remember { mutableStateOf(true) }
+    var selectedLocation by remember { mutableStateOf(initialLocation) }
+  val isError by remember {
+      derivedStateOf {
+          selectedLocation == null || selectedLocation!!.name.isEmpty() && locationQuery.isEmpty()
+   }
+  }
 
   Box(modifier = Modifier.fillMaxWidth()) {
     OutlinedTextField(
         value = if (shouldDisplayInitialLocation) initialLocation?.name ?: "" else locationQuery,
         onValueChange = {
           locationSearchViewModel.setQuery(it)
+            selectedLocation = null
           shouldDisplayInitialLocation = false
           showDropdown = true
+        },
+        isError = isError,
+        supportingText = {
+          if (isError) {
+            Text(context.getString(R.string.event_edit_location_error))
+          }
         },
         label = { Text(context.getString(R.string.event_creation_location_label)) },
         placeholder = { Text(context.getString(R.string.event_creation_location_input_label)) },
@@ -129,6 +143,7 @@ fun NominatimLocationPicker(
                 },
                 onClick = {
                   locationSearchViewModel.setQuery(location.name)
+                    selectedLocation = location
                   onLocationSelected(location)
                   showDropdown = false
                 },

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -119,6 +119,12 @@ fun EventCreationScreen(
           OutlinedTextField(
               modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.EVENT_TITLE),
               value = name,
+              isError = name.isEmpty(),
+              supportingText = {
+                  if (name.isEmpty()) {
+                      Text(context.getString(R.string.event_creation_name_error))
+                  }
+              },
               onValueChange = {
                 if (Utils.checkInputLength(it, TextLength.SMALL)) {
                   name = it
@@ -144,6 +150,12 @@ fun EventCreationScreen(
           OutlinedTextField(
               modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.SHORT_DESCRIPTION),
               value = shortDescription,
+              isError = shortDescription.isEmpty(),
+              supportingText = {
+                  if (shortDescription.isEmpty()) {
+                      Text(context.getString(R.string.event_creation_short_description_error))
+                  }
+              },
               onValueChange = {
                 if (Utils.checkInputLength(it, TextLength.MEDIUM)) {
                   shortDescription = it
@@ -197,6 +209,11 @@ fun EventCreationScreen(
           OutlinedTextField(
               modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.DESCRIPTION),
               value = longDescription,
+              supportingText = {
+                  if (longDescription.isEmpty()) {
+                      Text(context.getString(R.string.event_creation_description_error))
+                  }
+              },
               onValueChange = {
                 if (Utils.checkInputLength(it, TextLength.LARGE)) {
                   longDescription = it

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -121,9 +121,9 @@ fun EventCreationScreen(
               value = name,
               isError = name.isEmpty(),
               supportingText = {
-                  if (name.isEmpty()) {
-                      Text(context.getString(R.string.event_creation_name_error))
-                  }
+                if (name.isEmpty()) {
+                  Text(context.getString(R.string.event_creation_name_error))
+                }
               },
               onValueChange = {
                 if (Utils.checkInputLength(it, TextLength.SMALL)) {
@@ -152,9 +152,9 @@ fun EventCreationScreen(
               value = shortDescription,
               isError = shortDescription.isEmpty(),
               supportingText = {
-                  if (shortDescription.isEmpty()) {
-                      Text(context.getString(R.string.event_creation_short_description_error))
-                  }
+                if (shortDescription.isEmpty()) {
+                  Text(context.getString(R.string.event_creation_short_description_error))
+                }
               },
               onValueChange = {
                 if (Utils.checkInputLength(it, TextLength.MEDIUM)) {
@@ -210,9 +210,9 @@ fun EventCreationScreen(
               modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.DESCRIPTION),
               value = longDescription,
               supportingText = {
-                  if (longDescription.isEmpty()) {
-                      Text(context.getString(R.string.event_creation_description_error))
-                  }
+                if (longDescription.isEmpty()) {
+                  Text(context.getString(R.string.event_creation_description_error))
+                }
               },
               onValueChange = {
                 if (Utils.checkInputLength(it, TextLength.LARGE)) {

--- a/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventCreation.kt
@@ -209,6 +209,7 @@ fun EventCreationScreen(
           OutlinedTextField(
               modifier = Modifier.fillMaxWidth().testTag(EventCreationTestTags.DESCRIPTION),
               value = longDescription,
+              isError = longDescription.isEmpty(),
               supportingText = {
                 if (longDescription.isEmpty()) {
                   Text(context.getString(R.string.event_creation_description_error))

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -142,7 +142,7 @@ fun EventEditScreen(
               isError = name.isEmpty(),
               supportingText = {
                 if (name.isEmpty()) {
-                  context.getString(R.string.event_creation_name_error)
+                  Text(context.getString(R.string.event_creation_name_error))
                 }
               },
               onValueChange = { name = it },
@@ -151,6 +151,12 @@ fun EventEditScreen(
           OutlinedTextField(
               modifier = Modifier.fillMaxWidth().testTag(EventEditTestTags.SHORT_DESCRIPTION),
               value = shortDescription,
+              isError = shortDescription.isEmpty(),
+              supportingText = {
+                if (shortDescription.isEmpty()) {
+                  Text(context.getString(R.string.event_creation_short_description_error))
+                }
+              },
               onValueChange = { shortDescription = it },
               label = { Text(context.getString(R.string.event_creation_short_description_label)) })
 
@@ -184,6 +190,12 @@ fun EventEditScreen(
           OutlinedTextField(
               modifier = Modifier.fillMaxWidth().testTag(EventEditTestTags.DESCRIPTION),
               value = longDescription,
+              isError = longDescription.isEmpty(),
+              supportingText = {
+                if (longDescription.isEmpty()) {
+                  Text(context.getString(R.string.event_creation_description_error))
+                }
+              },
               onValueChange = { longDescription = it },
               label = { Text(context.getString(R.string.event_creation_description_label)) })
 

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -83,9 +83,9 @@ fun EventEditScreen(
 
   val eventToEdit = remember { eventViewModel.selectedEvent.value!! }
 
-  var name by remember { mutableStateOf(eventToEdit.title) }
-  var shortDescription by remember { mutableStateOf(eventToEdit.catchyDescription) }
-  var longDescription by remember { mutableStateOf(eventToEdit.description) }
+  var name by remember { mutableStateOf(eventToEdit.title.trim()) }
+  var shortDescription by remember { mutableStateOf(eventToEdit.catchyDescription.trim()) }
+  var longDescription by remember { mutableStateOf(eventToEdit.description.trim()) }
 
   var coauthorsAndBoolean =
       associationViewModel.associations.collectAsState().value.map {

--- a/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
+++ b/app/src/main/java/com/android/unio/ui/event/EventEdit.kt
@@ -139,6 +139,12 @@ fun EventEditScreen(
           OutlinedTextField(
               modifier = Modifier.fillMaxWidth().testTag(EventEditTestTags.EVENT_TITLE),
               value = name,
+              isError = name.isEmpty(),
+              supportingText = {
+                if (name.isEmpty()) {
+                  context.getString(R.string.event_creation_name_error)
+                }
+              },
               onValueChange = { name = it },
               label = { Text(context.getString(R.string.event_creation_name_label)) })
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -223,6 +223,8 @@
     <!-- Event Edit Component Strings -->
     <string name="event_edit_date_picker_desc">Sélectionner une date</string>
     <string name="event_edit_time_picker_desc">Sélectionner une heure</string>
+    <string name="event_edit_date_error">La date est manquante</string>
+    <string name="event_edit_time_error">L\'heure est manquante</string>
     <string name="event_edit_toast_more_button">Continuez à taper pour voir plus de résultats</string>
 
     <!-- Associations Overlay Strings -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -225,6 +225,7 @@
     <string name="event_edit_time_picker_desc">Sélectionner une heure</string>
     <string name="event_edit_date_error">La date est manquante</string>
     <string name="event_edit_time_error">L\'heure est manquante</string>
+    <string name="event_edit_location_error">Localisation erronée</string>
     <string name="event_edit_toast_more_button">Continuez à taper pour voir plus de résultats</string>
 
     <!-- Associations Overlay Strings -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -211,6 +211,8 @@
     <string name="event_creation_location_dropdown_points">…</string>
     <string name="event_creation_location_dropdown_more">Plus…</string>
     <string name="event_creation_name_error">Entrez un nom d\'événement</string>
+    <string name="event_creation_short_description_error">Entrez une courte description de l\'événement</string>
+    <string name="event_creation_description_error">Entrez une description de l\'événement</string>
 
     <!-- Event Edit Strings -->
     <string name="event_edit_title">Modifier </string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -210,6 +210,7 @@
     <string name="event_creation_location_input_label">Entrez une addresse</string>
     <string name="event_creation_location_dropdown_points">…</string>
     <string name="event_creation_location_dropdown_more">Plus…</string>
+    <string name="event_creation_name_error">Entrez un nom d\'événement</string>
 
     <!-- Event Edit Strings -->
     <string name="event_edit_title">Modifier </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,6 +215,8 @@
     <string name="event_creation_location_dropdown_points">…</string>
     <string name="event_creation_location_dropdown_more">More…</string>
     <string name="event_creation_name_error">Enter an event name</string>
+    <string name="event_creation_short_description_error">Enter an event short description</string>
+    <string name="event_creation_description_error">Enter an event description</string>
 
     <!-- Event Edit Strings -->
     <string name="event_edit_title">Edit </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,8 @@
     <!-- Event Edit Component Strings -->
     <string name="event_edit_date_picker_desc">Select date</string>
     <string name="event_edit_time_picker_desc">Select time</string>
+    <string name="event_edit_date_error">Date is missing</string>
+    <string name="event_edit_time_error">Time is missing</string>
     <string name="event_edit_toast_more_button">Continue typing to see more results</string>
 
     <!-- Associations Overlay Strings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,7 @@
     <string name="event_creation_location_input_label">Enter an address</string>
     <string name="event_creation_location_dropdown_points">…</string>
     <string name="event_creation_location_dropdown_more">More…</string>
+    <string name="event_creation_name_error">Enter an event name</string>
 
     <!-- Event Edit Strings -->
     <string name="event_edit_title">Edit </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,7 @@
     <string name="event_edit_time_picker_desc">Select time</string>
     <string name="event_edit_date_error">Date is missing</string>
     <string name="event_edit_time_error">Time is missing</string>
+    <string name="event_edit_location_error">Wrong location input</string>
     <string name="event_edit_toast_more_button">Continue typing to see more results</string>
 
     <!-- Associations Overlay Strings -->


### PR DESCRIPTION
This issue was flagged https://github.com/SwEnt-Group13/Unio/issues/269. It is part of polishing the inconsistencies of our app. In event creation/edition, you cannot save your work if some inputs are not filled out, but currently, it is not shown which input is missing. This task aims solve this issue