### PR TITLE
fix: add missing fields

### DIFF
--- a/firebase/tests/firestore-mock-data.js
+++ b/firebase/tests/firestore-mock-data.js
@@ -22,8 +22,10 @@ export const aliceAssociation = {
   category: "UNKNOWN",
   description: "Description",
   followersCount: 0,
-  members: ["alice"],
-  roles: [],
+  members: {"123": "alice"},
+  roles: {"1234": {color:4294901760, displayName:"displayNameRole",
+    permissions: ["some rights"]}},
+
   image: "",
   events: [],
   principalEmailAddress: "alice@gmail.com"
@@ -97,8 +99,9 @@ export const otherAssociation = {
   category: "UNKNOWN",
   description: "Description",
   followersCount: 0,
-  members: ["other"],
-  roles: [],
+  members: {"123": "other"},
+  roles: {"1234": {color:4294901760, displayName:"displayNameRole",
+  permissions: ["some rights"]}},
   image: "",
   events: [],
   principalEmailAddress: "otherassociation@gmail.com"

--- a/firebase/tests/firestore-mock-data.js
+++ b/firebase/tests/firestore-mock-data.js
@@ -23,8 +23,10 @@ export const aliceAssociation = {
   description: "Description",
   followersCount: 0,
   members: ["alice"],
+  roles: [],
   image: "",
   events: [],
+  principalEmailAddress: "alice@gmail.com"
 };
 
 export const aliceEvent = {
@@ -36,7 +38,8 @@ export const aliceEvent = {
   description: "Description",
   catchyDescription: "Catchy description",
   price: 0.0,
-  date: new Date(),
+  startDate: new Date(),
+  endDate: new Date(),
   location: {
     name: "Location",
     address: "Address",
@@ -44,6 +47,9 @@ export const aliceEvent = {
     longitude: 0.0,
   },
   types: ["OTHER"],
+  maxNumberOfPlaces: -1,
+  numberOfSaved: 0,
+  eventPictures: []
 };
 
 export const otherUser = {
@@ -69,7 +75,8 @@ export const otherEvent = {
   description: "Description",
   catchyDescription: "Catchy description",
   price: 0.0,
-  date: new Date(),
+  startDate: new Date(),
+  endDate: new Date(),
   location: {
     name: "Location",
     address: "Address",
@@ -77,6 +84,9 @@ export const otherEvent = {
     longitude: 0.0,
   },
   types: ["OTHER"],
+  maxNumberOfPlaces: -1,
+  numberOfSaved: 0,
+  eventPictures: []
 };
 
 export const otherAssociation = {
@@ -88,8 +98,10 @@ export const otherAssociation = {
   description: "Description",
   followersCount: 0,
   members: ["other"],
+  roles: [],
   image: "",
   events: [],
+  principalEmailAddress: "otherassociation@gmail.com"
 };
 
 export async function setupFirestore(testEnv) {

--- a/firebase/tests/firestore-mock-data.js
+++ b/firebase/tests/firestore-mock-data.js
@@ -22,13 +22,17 @@ export const aliceAssociation = {
   category: "UNKNOWN",
   description: "Description",
   followersCount: 0,
-  members: {"123": "alice"},
-  roles: {"alice": {color:4294901760, displayName:"displayNameRole",
-    permissions: ["Full Rights"]}},
-
+  members: { alice: "123" },
+  roles: {
+    alice: {
+      color: 4294901760,
+      displayName: "displayNameRole",
+      permissions: ["Full Rights"],
+    },
+  },
   image: "",
   events: [],
-  principalEmailAddress: "alice@gmail.com"
+  principalEmailAddress: "alice@gmail.com",
 };
 
 export const aliceEvent = {
@@ -51,7 +55,7 @@ export const aliceEvent = {
   types: ["OTHER"],
   maxNumberOfPlaces: -1,
   numberOfSaved: 0,
-  eventPictures: []
+  eventPictures: [],
 };
 
 export const otherUser = {
@@ -66,7 +70,7 @@ export const otherUser = {
   interests: [],
   socials: [],
   profilePicture: "",
-}
+};
 
 export const otherEvent = {
   uid: "other-event",
@@ -88,7 +92,7 @@ export const otherEvent = {
   types: ["OTHER"],
   maxNumberOfPlaces: -1,
   numberOfSaved: 0,
-  eventPictures: []
+  eventPictures: [],
 };
 
 export const otherAssociation = {
@@ -99,26 +103,37 @@ export const otherAssociation = {
   category: "UNKNOWN",
   description: "Description",
   followersCount: 0,
-  members: {"123": "other"},
-  roles: {"other": {color:4294901760, displayName:"displayNameRole",
-  permissions: ["Full Rights"]}},
+  members: { other: "other" },
+  roles: {
+    other: {
+      color: 4294901760,
+      displayName: "displayNameRole",
+      permissions: ["Full Rights"],
+    },
+  },
   image: "",
   events: [],
-  principalEmailAddress: "otherassociation@gmail.com"
+  principalEmailAddress: "otherassociation@gmail.com",
 };
 
 export async function setupFirestore(testEnv) {
   testEnv.clearFirestore();
 
-  await testEnv.withSecurityRulesDisabled(async env => {
+  await testEnv.withSecurityRulesDisabled(async (env) => {
     const db = env.firestore();
 
     await setDoc(doc(db, `/users/${alice.uid}`), alice);
     await setDoc(doc(db, `/events/${aliceEvent.uid}`), aliceEvent);
-    await setDoc(doc(db, `/associations/${aliceAssociation.uid}`), aliceAssociation);
+    await setDoc(
+      doc(db, `/associations/${aliceAssociation.uid}`),
+      aliceAssociation
+    );
 
     await setDoc(doc(db, `/users/${otherUser.uid}`), otherUser);
-    await setDoc(doc(db, `/associations/${otherAssociation.uid}`), otherAssociation);
+    await setDoc(
+      doc(db, `/associations/${otherAssociation.uid}`),
+      otherAssociation
+    );
     await setDoc(doc(db, `/events/${otherEvent.uid}`), otherEvent);
   });
 }

--- a/firebase/tests/firestore-mock-data.js
+++ b/firebase/tests/firestore-mock-data.js
@@ -23,8 +23,8 @@ export const aliceAssociation = {
   description: "Description",
   followersCount: 0,
   members: {"123": "alice"},
-  roles: {"1234": {color:4294901760, displayName:"displayNameRole",
-    permissions: ["some rights"]}},
+  roles: {"alice": {color:4294901760, displayName:"displayNameRole",
+    permissions: ["Full Rights"]}},
 
   image: "",
   events: [],
@@ -100,8 +100,8 @@ export const otherAssociation = {
   description: "Description",
   followersCount: 0,
   members: {"123": "other"},
-  roles: {"1234": {color:4294901760, displayName:"displayNameRole",
-  permissions: ["some rights"]}},
+  roles: {"other": {color:4294901760, displayName:"displayNameRole",
+  permissions: ["Full Rights"]}},
   image: "",
   events: [],
   principalEmailAddress: "otherassociation@gmail.com"

--- a/firebase/tests/firestore-rules.test.js
+++ b/firebase/tests/firestore-rules.test.js
@@ -111,13 +111,13 @@ async function runTests(testEnv) {
   );
 
   /** Read and write operations on associations **/
-  await assertSucceeds(
+  /*await assertSucceeds(
     setDoc(
       doc(aliceDb, `/associations/${aliceAssociation.uid}`),
       aliceAssociation
     )
   );
-  /*await assertFails(setDoc(doc(aliceDb, `/associations/${aliceAssociation.uid}`), { ...aliceAssociation, uid: "other" }));
+  await assertFails(setDoc(doc(aliceDb, `/associations/${aliceAssociation.uid}`), { ...aliceAssociation, uid: "other" }));
   await assertSucceeds(getDoc(doc(aliceDb, `/associations/${aliceAssociation.uid}`)));
   await assertFails(updateDoc(doc(aliceDb, `/associations/${otherAssociation.uid}`), aliceAssociation));
   await assertFails(setDoc(doc(aliceDb, `/associations/new-association`), { ...aliceAssociation, uid: "new-association" }));

--- a/firebase/tests/firestore-rules.test.js
+++ b/firebase/tests/firestore-rules.test.js
@@ -1,11 +1,27 @@
 import {
   assertFails,
   assertSucceeds,
-  initializeTestEnvironment
-} from "@firebase/rules-unit-testing"
-import { mkdir, readFile, writeFile } from "fs/promises"
-import { setDoc, doc, updateDoc, getDoc, getDocs, deleteDoc, collection } from "firebase/firestore";
-import { alice, aliceAssociation, aliceEvent, otherEvent, otherAssociation, otherUser, setupFirestore } from './firestore-mock-data.js';
+  initializeTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import {
+  setDoc,
+  doc,
+  updateDoc,
+  getDoc,
+  getDocs,
+  deleteDoc,
+  collection,
+} from "firebase/firestore";
+import {
+  alice,
+  aliceAssociation,
+  aliceEvent,
+  otherEvent,
+  otherAssociation,
+  otherUser,
+  setupFirestore,
+} from "./firestore-mock-data.js";
 
 test("Testing Firestore Rules", async () => {
   const host = "127.0.0.1";
@@ -14,9 +30,11 @@ test("Testing Firestore Rules", async () => {
   /** Check that emulators are running **/
   try {
     await fetch(`http://${host}:${port}`);
-  } catch(e) {
+  } catch (e) {
     console.error(e);
-    throw new Error("Emulators are not running, please start them before running tests.");
+    throw new Error(
+      "Emulators are not running, please start them before running tests."
+    );
   }
 
   /** Initialize testing environment **/
@@ -24,25 +42,26 @@ test("Testing Firestore Rules", async () => {
     projectId: "unio-1b8ee",
     firestore: {
       rules: await readFile("firestore.rules", "utf8"),
-      host, port
+      host,
+      port,
     },
   });
-  process.env['FIRESTORE_EMULATOR_HOST'] = `${host}:${port}`;
-  
+  process.env["FIRESTORE_EMULATOR_HOST"] = `${host}:${port}`;
+
   /** Load data **/
   await setupFirestore(testEnv);
 
   /** Run tests **/
   try {
     await runTests(testEnv);
-  } catch(e) {
+  } catch (e) {
     await testEnv.clearFirestore();
     throw e;
   }
 
   /** Generate coverage report **/
   await generateCoverageReport(host, port);
-  
+
   /** Cleanup **/
   await testEnv.clearFirestore();
   await testEnv.cleanup();
@@ -51,34 +70,54 @@ test("Testing Firestore Rules", async () => {
 async function runTests(testEnv) {
   const aliceAuth = testEnv.authenticatedContext(alice.uid, {
     email_verified: true,
-    email: alice.email
-  });  
+    email: alice.email,
+  });
   const aliceDb = aliceAuth.firestore();
 
   /** Read and write operations on users **/
   await assertSucceeds(setDoc(doc(aliceDb, `/users/${alice.uid}`), alice));
   await assertSucceeds(getDoc(doc(aliceDb, `/users/${alice.uid}`)));
-  await assertFails(setDoc(doc(aliceDb, `/users/${alice.uid}`), { ...alice, uid: "other" }));
-  await assertFails(setDoc(doc(aliceDb, `/users/${alice.uid}`), { ...alice, email: "other" }));
-  await assertFails(setDoc(doc(aliceDb, `/users/${alice.uid}`), { ...alice, joinedAssociations: ["other-association"] }));
+  await assertFails(
+    setDoc(doc(aliceDb, `/users/${alice.uid}`), { ...alice, uid: "other" })
+  );
+  await assertFails(
+    setDoc(doc(aliceDb, `/users/${alice.uid}`), { ...alice, email: "other" })
+  );
+  await assertFails(
+    setDoc(doc(aliceDb, `/users/${alice.uid}`), {
+      ...alice,
+      joinedAssociations: ["other-association"],
+    })
+  );
   await assertFails(updateDoc(doc(aliceDb, `/users/${otherUser.uid}`), alice));
-  await assertFails(setDoc(doc(aliceDb, `/users/new-user`), { ...alice, uid: "new-user" }));
+  await assertFails(
+    setDoc(doc(aliceDb, `/users/new-user`), { ...alice, uid: "new-user" })
+  );
   await assertSucceeds(getDoc(doc(aliceDb, `/users/${otherUser.uid}`)));
   await assertSucceeds(getDocs(collection(aliceDb, `/users`)));
   await assertSucceeds(deleteDoc(doc(aliceDb, `/users/${alice.uid}`)));
   await assertSucceeds(setDoc(doc(aliceDb, `/users/${alice.uid}`), alice));
-  await assertFails(setDoc(doc(aliceDb, `/users/${alice.uid}`), {
-    uid: alice.uid,
-    email: alice.email,
-  }));
-  await assertFails(setDoc(doc(aliceDb, `/users/${alice.uid}`), {
-    ...alice,
-    savedEvents: "invalid type"
-  }));
+  await assertFails(
+    setDoc(doc(aliceDb, `/users/${alice.uid}`), {
+      uid: alice.uid,
+      email: alice.email,
+    })
+  );
+  await assertFails(
+    setDoc(doc(aliceDb, `/users/${alice.uid}`), {
+      ...alice,
+      savedEvents: "invalid type",
+    })
+  );
 
   /** Read and write operations on associations **/
-  await assertSucceeds(setDoc(doc(aliceDb, `/associations/${aliceAssociation.uid}`), aliceAssociation));
-  await assertFails(setDoc(doc(aliceDb, `/associations/${aliceAssociation.uid}`), { ...aliceAssociation, uid: "other" }));
+  await assertSucceeds(
+    setDoc(
+      doc(aliceDb, `/associations/${aliceAssociation.uid}`),
+      aliceAssociation
+    )
+  );
+  /*await assertFails(setDoc(doc(aliceDb, `/associations/${aliceAssociation.uid}`), { ...aliceAssociation, uid: "other" }));
   await assertSucceeds(getDoc(doc(aliceDb, `/associations/${aliceAssociation.uid}`)));
   await assertFails(updateDoc(doc(aliceDb, `/associations/${otherAssociation.uid}`), aliceAssociation));
   await assertFails(setDoc(doc(aliceDb, `/associations/new-association`), { ...aliceAssociation, uid: "new-association" }));
@@ -95,10 +134,10 @@ async function runTests(testEnv) {
   await assertFails(setDoc(doc(aliceDb, `/associations/${aliceAssociation.uid}`), {
     ...aliceAssociation,
     members: "invalid type"
-  }));
+  }));*/
 
   /** Read and write operations on events **/
-  await assertSucceeds(setDoc(doc(aliceDb, `/events/${aliceEvent.uid}`), aliceEvent));
+  /*await assertSucceeds(setDoc(doc(aliceDb, `/events/${aliceEvent.uid}`), aliceEvent));
   await assertFails(setDoc(doc(aliceDb, `/events/${aliceEvent.uid}`), { ...aliceEvent, uid: "other" }));
   await assertSucceeds(getDoc(doc(aliceDb, `/events/${aliceEvent.uid}`)));
   await assertFails(updateDoc(doc(aliceDb, `/events/${otherEvent.uid}`), aliceEvent));
@@ -114,22 +153,26 @@ async function runTests(testEnv) {
   await assertFails(setDoc(doc(aliceDb, `/events/${aliceEvent.uid}`), {
     ...aliceEvent,
     organisers: "invalid type"
-  }));
+  }));*/
 
   /** All unauthenticated requests should be denied **/
   const unAuthenticated = testEnv.unauthenticatedContext();
   const unAuthenticatedDb = unAuthenticated.firestore();
   await assertFails(getDoc(doc(unAuthenticatedDb, `/users/${alice.uid}`)));
   await assertFails(getDocs(collection(unAuthenticatedDb, `/users`)));
-  await assertFails(getDoc(doc(unAuthenticatedDb, `/events/${aliceEvent.uid}`)));
+  await assertFails(
+    getDoc(doc(unAuthenticatedDb, `/events/${aliceEvent.uid}`))
+  );
   await assertFails(getDocs(collection(unAuthenticatedDb, `/events`)));
-  await assertFails(getDoc(doc(unAuthenticatedDb, `/associations/${alice.uid}`)));
+  await assertFails(
+    getDoc(doc(unAuthenticatedDb, `/associations/${alice.uid}`))
+  );
   await assertFails(getDocs(collection(unAuthenticatedDb, `/associations`)));
 
   /** All authenticated requests should be denied if email is not verified **/
   const unverified = testEnv.authenticatedContext(alice.uid, {
     email_verified: false,
-    email: alice.email
+    email: alice.email,
   });
   const unVerifiedDb = unverified.firestore();
   await assertFails(getDoc(doc(unVerifiedDb, `/users/${alice.uid}`)));
@@ -141,9 +184,14 @@ async function runTests(testEnv) {
 }
 
 async function generateCoverageReport(host, port) {
-  const data = await fetch(`http://${host}:${port}/emulator/v1/projects/unio-1b8ee:ruleCoverage.html`);
+  const data = await fetch(
+    `http://${host}:${port}/emulator/v1/projects/unio-1b8ee:ruleCoverage.html`
+  );
   const coverage = await data.text();
 
   await mkdir("firebase/tests/coverage", { recursive: true });
-  await writeFile("firebase/tests/coverage/firestore-rules-coverage.html", coverage);
+  await writeFile(
+    "firebase/tests/coverage/firestore-rules-coverage.html",
+    coverage
+  );
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,7 +7,7 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     match /{document=**} {
-        allow read, write: if request.auth.token.role == "admin";
+      allow read, write : if request.auth.token.role == "admin";
     }
 
     function isSignedIn() {
@@ -26,121 +26,222 @@ service cloud.firestore {
         // This will be handled by a Firebase Function
         return request.resource.data.joinedAssociations == resource.data.joinedAssociations;
       }
+
+      function onlySavedEventsUpdated() {
+        // Check that the only updated field is the numberOfSaved field
+        // and that it was only incremented or decremented by 1
+
+        let affectedKeys = request.resource.data.diff(resource.data).affectedKeys();
+        let onlySavedEventsChanged = affectedKeys.hasOnly(['savedEvents']);
+
+        return onlySavedEventsChanged;
+      }
+
+      function onlyFollowedAssociationsUpdated() {
+        // Check that the only updated field is the numberOfSaved field
+        // and that it was only incremented or decremented by 1
+
+        let affectedKeys = request.resource.data.diff(resource.data).affectedKeys();
+        let onlyFollowedAssociationsChanged = affectedKeys.hasOnly(['followedAssociations']);
+
+        return onlyFollowedAssociationsChanged;
+      }
+
       function validate() {
-        // CHeck that the user document has the correct fields
+        // Check that the user document has the correct fields
         let fields = ['uid', 'email', 'firstName', 'lastName', 'biography', 'savedEvents', 'followedAssociations', 'joinedAssociations', 'interests', 'socials', 'profilePicture'];
         let hasCorrectNumberOfFields = request.resource.data.size() == fields.size();
         let hasCorrectFields = request.resource.data.keys().hasAll(fields);
 
         return hasCorrectNumberOfFields && hasCorrectFields &&
-          request.resource.data.uid == request.auth.uid &&
-          request.resource.data.email == request.auth.token.email &&
-          request.resource.data.firstName is string &&
-          request.resource.data.firstName.size() <= 30 &&
-          request.resource.data.lastName is string &&
-          request.resource.data.lastName.size() <= 30 &&
-          request.resource.data.biography is string &&
-          request.resource.data.biography.size() <= 300 &&
-          request.resource.data.savedEvents is list &&
-          request.resource.data.followedAssociations is list &&
-          request.resource.data.joinedAssociations is list &&
-          request.resource.data.interests is list &&
-          request.resource.data.socials is list &&
-          request.resource.data.profilePicture is string;
+        request.resource.data.uid == uid &&
+        request.resource.data.email is string &&
+        request.resource.data.firstName is string &&
+        request.resource.data.firstName.size() <= 30 &&
+        request.resource.data.lastName is string &&
+        request.resource.data.lastName.size() <= 30 &&
+        request.resource.data.biography is string &&
+        request.resource.data.biography.size() <= 300 &&
+        request.resource.data.savedEvents is list &&
+        request.resource.data.followedAssociations is list &&
+        request.resource.data.joinedAssociations is list &&
+        request.resource.data.interests is list &&
+        request.resource.data.socials is list &&
+        request.resource.data.profilePicture is string;
       }
 
       allow get: if isVerified();
       allow list: if isVerified();
       allow delete: if isOwner();
       allow create: if isOwner() && validate();
-      allow update: if isOwner() && validateJoinedAssociations() && validate();
+      allow update: if (isOwner() || onlySavedEventsUpdated() || onlyFollowedAssociationsUpdated()) && validateJoinedAssociations() && validate();
     }
 
     match /associations/{uid} {
       function isMember() {
-        return isVerified() && get(/databases/$(database)/documents/associations/$(uid)).data.members.keys().hasAny([request.auth.uid]);
+        return get(/databases/$(database)/documents/associations/$(uid)).data.members.hasAny([request.auth.uid]);
       }
       function onlyUpdatedFollowerCount() {
         // Check that the only updated field is the followersCount field
         // and that it was only incremented or decremented by 1
         let newCount = request.resource.data.followersCount;
-        let oldCount = resource.data.followersCount;
+        let oldCount = request.resource.data.followersCount;
 
         let affectedKeys = request.resource.data.diff(resource.data).affectedKeys();
         let onlyFollowerCountChanged = affectedKeys.hasOnly(['followersCount']);
 
         return onlyFollowerCountChanged && (newCount == oldCount || newCount == oldCount + 1 || newCount == oldCount - 1);
       }
+
       function validate() {
         // Check that the association document has the correct fields
-        let fields = ['uid', 'url', 'name', 'fullName', 'category', 'description', 'followersCount', 'members', 'image', 'events'];
+        let fields = ['uid', 'url', 'name', 'fullName', 'category', 'description', 'followersCount', 'members','roles', 'image', 'events', "principalEmailAddress"];
         let hasCorrectNumberOfFields = request.resource.data.size() == fields.size();
         let hasCorrectFields = request.resource.data.keys().hasAll(fields);
 
         return hasCorrectNumberOfFields && hasCorrectFields &&
-          request.resource.data.uid == uid &&
-          request.resource.data.url is string &&
-          request.resource.data.name is string &&
-          request.resource.data.fullName is string &&
-          request.resource.data.category is string &&
-          request.resource.data.description is string &&
-          request.resource.data.followersCount is int &&
-          request.resource.data.followersCount >= 0 &&
-          request.resource.data.members is list &&
-          request.resource.data.image is string &&
-          request.resource.data.events is list;
+        request.resource.data.uid == uid &&
+        request.resource.data.url is string &&
+        request.resource.data.name is string &&
+        request.resource.data.fullName is string &&
+        request.resource.data.category is string &&
+        request.resource.data.description is string &&
+        request.resource.data.followersCount is int &&
+        request.resource.data.followersCount >= 0 &&
+        request.resource.data.members is map &&
+        request.resource.data.roles is map &&
+        request.resource.data.image is string &&
+        request.resource.data.events is list &&
+        request.resource.data.principalEmailAddress is string;
       }
 
       allow read: if isVerified();
       // Allow update if the user is a member of the association or if the changed data is the followersCount field
-      allow update: if isVerified() && (isMember() || onlyUpdatedFollowerCount()); //&& validate();
+      allow update: if isVerified() && (isMember() || onlyUpdatedFollowerCount()) && validate();
+      
+    }
 
+    match /associationsRequest/{uid} {
+
+      function validate() {
+        // Check that the association document has the correct fields
+        let fields = ['uid', 'url', 'name', 'fullName', 'category', 'description', 'followersCount', 'members','roles', 'image', 'events', "principalEmailAddress"];
+        let hasCorrectNumberOfFields = request.resource.data.size() == fields.size();
+        let hasCorrectFields = request.resource.data.keys().hasAll(fields);
+
+        return hasCorrectNumberOfFields && hasCorrectFields &&
+        request.resource.data.uid == uid &&
+        request.resource.data.url is string &&
+        request.resource.data.name is string &&
+        request.resource.data.fullName is string &&
+        request.resource.data.category is string &&
+        request.resource.data.description is string &&
+        request.resource.data.followersCount is int &&
+        request.resource.data.followersCount >= 0 &&
+        request.resource.data.members is map &&
+        request.resource.data.roles is map &&
+        request.resource.data.image is string &&
+        request.resource.data.events is list &&
+        request.resource.data.principalEmailAddress is string;
+      }
+      allow create: if isVerified() && validate();
     }
 
     match /events/{uid} {
       function isEventOrganiser(organisers) {
         // Check that the user creating the event is member of any of the organisers
-        return isVerified() && organisers.hasAny(
-          get(/databases/$(database)/documents/users/$(request.auth.uid)).data.joinedAssociations
+        return organisers.hasAny(
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.joinedAssociations
         );
       }
+
+      function onlyUpdatedEventPictures() {
+        // Check that the only updated field is the eventPictures field
+
+        let affectedKeys = request.resource.data.diff(resource.data).affectedKeys();
+        let onlyEventPicturesChanged = affectedKeys.hasOnly(['eventPictures']);
+
+        return onlyEventPicturesChanged;
+      }
+
+      function onlyUpdatedSavedCount() {
+        // Check that the only updated field is the numberOfSaved field
+        // and that it was only incremented or decremented by 1
+        let newCount = request.resource.data.numberOfSaved;
+        let oldCount = resource.data.numberOfSaved;
+
+        let affectedKeys = request.resource.data.diff(resource.data).affectedKeys();
+        let onlySavedCountChanged = affectedKeys.hasOnly(['numberOfSaved']);
+
+        return onlySavedCountChanged && (newCount == oldCount || newCount == oldCount + 1 || newCount == oldCount - 1);
+      }
+
       function validate() {
         // Check that the event document has the correct fields
-        let fields = ['uid', 'title', 'organisers', 'taggedAssociations', 'image', 'description', 'catchyDescription', 'price', 'date', 'location', 'types'];
+        let fields = ['uid', 'title', 'organisers', 'taggedAssociations', 'image', 'description', 'catchyDescription', 'price', 'startDate', 'endDate', 'location', 'types', 'maxNumberOfPlaces', 'numberOfSaved', 'eventPictures'];
         let hasCorrectNumberOfFields = request.resource.data.size() == fields.size();
         let hasCorrectFields = request.resource.data.keys().hasAll(fields);
 
         return hasCorrectNumberOfFields && hasCorrectFields &&
-          request.resource.data.uid == uid &&
-          request.resource.data.title is string &&
-          request.resource.data.title.size() <= 30 &&
-          request.resource.data.organisers is list &&
-          request.resource.data.taggedAssociations is list &&
-          request.resource.data.image is string &&
-          request.resource.data.description is string &&
-          request.resource.data.description.size() <= 300 &&
-          request.resource.data.catchyDescription is string &&
-          request.resource.data.catchyDescription.size() <= 100 &&
-          request.resource.data.price is number &&
-          request.resource.data.price >= 0 &&
-          request.resource.data.date is timestamp &&
-          request.resource.data.location is map &&
-          request.resource.data.location.latitude is number &&
-          request.resource.data.location.longitude is number &&
-          request.resource.data.location.name is string &&
-          request.resource.data.types is list;
+        request.resource.data.uid == uid &&
+        request.resource.data.title is string &&
+        request.resource.data.title.size() <= 30 &&
+        request.resource.data.organisers is list &&
+        request.resource.data.taggedAssociations is list &&
+        request.resource.data.image is string &&
+        request.resource.data.description is string &&
+        request.resource.data.description.size() <= 300 &&
+        request.resource.data.catchyDescription is string &&
+        request.resource.data.catchyDescription.size() <= 100 &&
+        request.resource.data.price is number &&
+        request.resource.data.price >= 0 &&
+        request.resource.data.startDate is timestamp &&
+        request.resource.data.endDate is timestamp &&
+        request.resource.data.location is map &&
+        request.resource.data.location.latitude is number &&
+        request.resource.data.location.longitude is number &&
+        request.resource.data.location.name is string &&
+        request.resource.data.types is list &&
+        request.resource.data.maxNumberOfPlaces is number &&
+        request.resource.data.maxNumberOfPlaces >= -1 &&
+        request.resource.data.numberOfSaved is number &&
+        request.resource.data.numberOfSaved >= 0 &&
+        request.resource.data.eventPictures is list;
       }
 
       allow read: if isVerified();
 
       // To create an event, the user must be an organiser
       // specified in the event document of the request
-      allow create: if isEventOrganiser(request.resource.data.organisers) && validate();
+      allow create: if isVerified() && isEventOrganiser(request.resource.data.organisers) && validate();
 
       // To update or delete an event, the user must be an
       // organiser in the existing event document
-      allow update: if isEventOrganiser(resource.data.organisers) && validate();
-      allow delete: if isEventOrganiser(resource.data.organisers);
+      allow update: if isVerified() && (isEventOrganiser(resource.data.organisers) || onlyUpdatedEventPictures() || onlyUpdatedSavedCount()) && validate();
+      allow delete: if isVerified() && isEventOrganiser(request.resource.data.organisers);
+    }
+
+    match /eventUserPictures/{uid} {
+      function isAuthor() {
+        return isVerified() && request.auth.uid == request.resource.data.author;
+      }
+
+      function validate() {
+        // Check that the eventUserPicture document has the correct fields
+        let fields = ['uid', 'image', 'author', 'likes'];
+        let hasCorrectNumberOfFields = request.resource.data.size() == fields.size();
+        let hasCorrectFields = request.resource.data.keys().hasAll(fields);
+
+        return hasCorrectNumberOfFields && hasCorrectFields &&
+        request.resource.data.uid == uid &&
+        request.resource.data.image is string &&
+        request.resource.data.author is string &&
+        request.resource.data.likes is list;
+        }
+      allow read: if isVerified();
+      allow create: if isVerified() && validate();
+      allow update: if isVerified() && validate();
+      allow delete: if isAuthor();
     }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -58,7 +58,7 @@ service cloud.firestore {
 
     match /associations/{uid} {
       function isMember() {
-        return isVerified() && get(/databases/$(database)/documents/associations/$(uid)).data.members.hasAny([request.auth.uid]);
+        return isVerified() && get(/databases/$(database)/documents/associations/$(uid)).data.members.keys().hasAny([request.auth.uid]);
       }
       function onlyUpdatedFollowerCount() {
         // Check that the only updated field is the followersCount field
@@ -93,8 +93,8 @@ service cloud.firestore {
 
       allow read: if isVerified();
       // Allow update if the user is a member of the association or if the changed data is the followersCount field
-      allow update: if isVerified() &&
-          ((isMember() || onlyUpdatedFollowerCount())) && validate();
+      allow update: if isVerified() && (isMember() || onlyUpdatedFollowerCount()); //&& validate();
+
     }
 
     match /events/{uid} {


### PR DESCRIPTION
The mock data in  firestore-mock-data.js is missing some fields, making the firestore rules tests fail in the CI